### PR TITLE
nested java hook fixed

### DIFF
--- a/src/agent/core/agent.c
+++ b/src/agent/core/agent.c
@@ -302,7 +302,7 @@ static JNI_GetCreatedJavaVMs_t get_jvm_func_legacy(void) {
     return NULL;
 }
 
-static JNIEnv* get_jni_env(void) {
+JNIEnv* get_jni_env(void) {
     if (!g_jvm) {
         int api = get_device_api_level();
         JNI_GetCreatedJavaVMs_t getVMs = NULL;

--- a/src/agent/include/agent/globals.h
+++ b/src/agent/include/agent/globals.h
@@ -29,5 +29,6 @@ extern JavaVM* g_java_vm;
 extern int g_default_hook_type;
 
 JNIEnv* get_current_jni_env(void);
+JNIEnv* get_jni_env(void);
 
 #endif


### PR DESCRIPTION
Nested java hook problem fixed

```java
public String childHook(String param) {
    return param + " child method";
}

public String parentHook(String param) {
    String childValue = childHook(param);
    return childValue + param;
}
```

Previously, we couldn’t hook child methods (like childHook) when they were called from a parent method (parentHook). With this update, nested Java hooks are now supported