### PR TITLE
Java onLeave() type-casting problem fixed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,36 +302,72 @@ jobs:
           Dynamic Instrumentation Toolkit for Android ARM64
 
           ### What's New
-            - **Nested Java Hook Support**: Full support for recursive/nested Java method hooks. When a hooked method calls another hooked method, both hooks trigger correctly.
-
-            \`\`\`java
-            // Java code
-            public String parentHook(String s) {
-                return childHook(s);  // calls another hooked method
-            }
-            \`\`\`
+            - **Java String Return Value Support**: Read and modify Java String return values in onLeave callbacks. The \`retval\` parameter now includes both raw pointer (\`retval.raw\`) and string value (\`retval.value\`). Use \`JNI.string()\` to create new strings.
 
             \`\`\`lua
-            -- Both hooks work correctly
-            hook("com/example/App", "parentHook", "(Ljava/lang/String;)Ljava/lang/String;", {
-                onEnter = function(args) print("[PARENT] onEnter") end,
-                onLeave = function(ret) print("[PARENT] onLeave") return ret end
+            -- Test script for Java String return values
+            -- Target: com.example.reneftestapp
+
+            print("[*] Starting Java String hook test...")
+
+            -- Hook childHook - modify return value
+            hook("com/example/reneftestapp/MainActivity", "childHook", "(Ljava/lang/String;)Ljava/lang/String;", {
+                onEnter = function(args)
+                    print("[+] childHook called")
+                    print("    this = " .. string.format("0x%x", args[1]))
+                    print("    param (jstring ref) = " .. string.format("0x%x", args[2]))
+                end,
+                onLeave = function(retval)
+                    print("[+] childHook onLeave")
+                    print("    Original: \\"" .. (retval.value or "nil") .. "\\"")
+
+                    -- Modify the return value!
+                    local newValue = "HOOKED BY RENEF!"
+                    print("    Replacing with: \\"" .. newValue .. "\\"")
+
+                    return JNI.string(newValue)
+                end
             })
-            hook("com/example/App", "childHook", "(Ljava/lang/String;)Ljava/lang/String;", {
-                onEnter = function(args) print("[CHILD] onEnter") end,
-                onLeave = function(ret) print("[CHILD] onLeave") return ret end
+
+            -- Hook parentHook - just observe
+            hook("com/example/reneftestapp/MainActivity", "parentHook", "(Ljava/lang/String;)Ljava/lang/String;", {
+                onEnter = function(args)
+                    print("[+] parentHook called")
+                    print("    this = " .. string.format("0x%x", args[1]))
+                    print("    param (jstring ref) = " .. string.format("0x%x", args[2]))
+                end,
+                onLeave = function(retval)
+                    print("[+] parentHook onLeave")
+                    print("    Return (raw ref): " .. string.format("0x%x", retval.raw))
+                    if retval.value then
+                        print("    Return (string): \\"" .. retval.value .. "\\"")
+                    end
+                    return retval.raw
+                end
             })
+
+            print("[+] Hooks installed!")
+            print("[*] childHook return value will be replaced with 'HOOKED BY RENEF!'")
             \`\`\`
 
-            **Output:**
+            - **Android Client for Termux**: Run renef client directly on device without a PC. Build with \`make client-android\` and deploy with \`make deploy-local\`.
+
+            \`\`\`bash
+            # Build Android client
+            make client-android
+            make deploy-local
+
+            # In Termux/ADB shell
+            su
+            /data/local/tmp/renef_server &
+            /data/local/tmp/renef --local
             \`\`\`
-            [PARENT] onEnter
-            [CHILD] onEnter
-            [CHILD] onLeave
-            [PARENT] onLeave
-            \`\`\`
+
+            - **Nested Java Hook Support**: Full support for recursive/nested Java method hooks with proper call stack tracking.
 
             - **File API Fix**: File.read() now correctly handles /proc files and other special files.
+
+            *Thanks to @AbhiTheModder and @FatalSec for their feedback.*
 
           ${COMMITS}
 

--- a/scripts/examples/java_hook.lua
+++ b/scripts/examples/java_hook.lua
@@ -1,16 +1,43 @@
-hook("com/example/reneftestapp/MainActivity", "hookTest", "(Ljava/lang/String;)Ljava/lang/String;", {
-      onEnter = function(args)
-          print("[onEnter] hookTest called")
-          print("  param1 ref = " .. string.format("0x%x", args[2]))
-      end,
-      onLeave = function(retval)
-          print("[onLeave] Original return: " .. string.format("0x%x", retval))
+-- Test script for Java String return values
+-- Target: com.example.reneftestapp
 
-          local newStr = Jni.newStringUTF("HOOKED!")
-          print("[onLeave] Returning: 'HOOKED!' (raw ptr: " .. string.format("0x%x", newStr) .. ")")
+print("[*] Starting Java String hook test...")
 
-          return newStr
-      end
-  })
+-- Hook childHook - modify return value
+hook("com/example/reneftestapp/MainActivity", "childHook", "(Ljava/lang/String;)Ljava/lang/String;", {
+    onEnter = function(args)
+        print("[+] childHook called")
+        print("    this = " .. string.format("0x%x", args[1]))
+        print("    param (jstring ref) = " .. string.format("0x%x", args[2]))
+    end,
+    onLeave = function(retval)
+        print("[+] childHook onLeave")
+        print("    Original: \"" .. (retval.value or "nil") .. "\"")
 
-  print("[+] Hook installed")
+        -- Modify the return value!
+        local newValue = "HOOKED BY RENEF!"
+        print("    Replacing with: \"" .. newValue .. "\"")
+
+        return JNI.string(newValue)
+    end
+})
+
+-- Hook parentHook - just observe
+hook("com/example/reneftestapp/MainActivity", "parentHook", "(Ljava/lang/String;)Ljava/lang/String;", {
+    onEnter = function(args)
+        print("[+] parentHook called")
+        print("    this = " .. string.format("0x%x", args[1]))
+        print("    param (jstring ref) = " .. string.format("0x%x", args[2]))
+    end,
+    onLeave = function(retval)
+        print("[+] parentHook onLeave")
+        print("    Return (raw ref): " .. string.format("0x%x", retval.raw))
+        if retval.value then
+            print("    Return (string): \"" .. retval.value .. "\"")
+        end
+        return retval.raw
+    end
+})
+
+print("[+] Hooks installed!")
+print("[*] childHook return value will be replaced with 'HOOKED BY RENEF!'")

--- a/src/agent/include/agent/hook_java.h
+++ b/src/agent/include/agent/hook_java.h
@@ -48,6 +48,10 @@ typedef struct {
     // Stored return value from JNI reflection call
     uint64_t stored_return_value;
     bool has_stored_return;
+
+    // Stored string value for object return types (if applicable)
+    char* stored_string_value;
+    bool has_stored_string;
 } JavaHookInfo;
 
 extern JavaHookInfo g_java_hooks[MAX_JAVA_HOOKS];


### PR DESCRIPTION
- **Java String Return Value Support**: Read and modify Java String return values in onLeave callbacks. The `retval` parameter now includes both raw pointer (`retval.raw`) and string value (`retval.value`). Use `JNI.string()` to create new strings.

```lua
-- Test script for Java String return values
-- Target: com.example.reneftestapp

print("[*] Starting Java String hook test...")

-- Hook childHook - modify return value
hook("com/example/reneftestapp/MainActivity", "childHook", "(Ljava/lang/String;)Ljava/lang/String;", {
    onEnter = function(args)
        print("[+] childHook called")
        print("    this = " .. string.format("0x%x", args[1]))
        print("    param (jstring ref) = " .. string.format("0x%x", args[2]))
    end,
    onLeave = function(retval)
        print("[+] childHook onLeave")
        print("    Original: \"" .. (retval.value or "nil") .. "\"")

        -- Modify the return value!
        local newValue = "HOOKED BY RENEF!"
        print("    Replacing with: \"" .. newValue .. "\"")

        return JNI.string(newValue)
    end
})

-- Hook parentHook - just observe
hook("com/example/reneftestapp/MainActivity", "parentHook", "(Ljava/lang/String;)Ljava/lang/String;", {
    onEnter = function(args)
        print("[+] parentHook called")
        print("    this = " .. string.format("0x%x", args[1]))
        print("    param (jstring ref) = " .. string.format("0x%x", args[2]))
    end,
    onLeave = function(retval)
        print("[+] parentHook onLeave")
        print("    Return (raw ref): " .. string.format("0x%x", retval.raw))
        if retval.value then
            print("    Return (string): \"" .. retval.value .. "\"")
        end
        return retval.raw
    end
})

print("[+] Hooks installed!")
print("[*] childHook return value will be replaced with 'HOOKED BY RENEF!'")
```
