### PR TITLE
pltgot-hook-fix

### DIFF
--- a/src/agent/core/globals.c
+++ b/src/agent/core/globals.c
@@ -31,7 +31,6 @@ JNIEnv* g_current_jni_env = NULL;
 
 JavaVM* g_java_vm = NULL;
 
-int g_default_hook_type = HOOK_TRAMPOLINE;
 
 JNIEnv* get_current_jni_env(void) {
     JNIEnv* env = NULL;

--- a/src/agent/hook/native.c
+++ b/src/agent/hook/native.c
@@ -6,6 +6,9 @@
 #include <errno.h>
 #include <sys/mman.h>
 #include <pthread.h>
+#include <dlfcn.h>
+#include <link.h>
+#include <elf.h>
 #include <capstone/capstone.h>
 #include <capstone/arm64.h>
 
@@ -99,59 +102,167 @@ bool is_pc_relative(void* insn_ptr) {
     }
 }
 
-void** find_got_entry(void* func_addr) {
+// --- Dynamic PLT/GOT resolution via dl_iterate_phdr ---
 
+struct got_scan_ctx {
+    const char* sym_name;       // Symbol name to find (e.g. "memcpy")
+    const char* caller_lib;     // Optional: only patch this library's GOT
+    void* hook_func;            // The hook thunk to redirect to
+    HookInfo* hook_info;        // Where to store patched GOT entries
+    void* original_func;        // The resolved original function address
+};
 
-    uint32_t* insns = (uint32_t*)func_addr;
+static int got_scan_callback(struct dl_phdr_info *info, size_t size, void *data) {
+    struct got_scan_ctx *ctx = (struct got_scan_ctx *)data;
 
-    if ((insns[0] & 0x9F000000) == 0x90000000) {
-        uint64_t page = ((uint64_t)func_addr & ~0xFFFULL);
-        int64_t immhi = (insns[0] >> 5) & 0x7FFFF;
-        int64_t immlo = (insns[0] >> 29) & 0x3;
-        int64_t imm = ((immhi << 2) | immlo) << 12;
-        if (imm & (1ULL << 32)) {
-            imm |= 0xFFFFFFFF00000000ULL;
+    // Skip entries with no name (vdso, main executable)
+    if (!info->dlpi_name || strlen(info->dlpi_name) == 0) {
+        return 0;
+    }
+
+    // If caller_lib is specified, only scan matching libraries
+    // caller_lib can be a single name or comma-separated list
+    if (ctx->caller_lib && strlen(ctx->caller_lib) > 0) {
+        bool match = false;
+        char callers_copy[1024];
+        strncpy(callers_copy, ctx->caller_lib, sizeof(callers_copy) - 1);
+        callers_copy[sizeof(callers_copy) - 1] = '\0';
+
+        char* saveptr = NULL;
+        char* token = strtok_r(callers_copy, ",", &saveptr);
+        while (token) {
+            if (strstr(info->dlpi_name, token)) {
+                match = true;
+                break;
+            }
+            token = strtok_r(NULL, ",", &saveptr);
         }
-        page += imm;
+        if (!match) return 0;
+    } else {
+        // No caller specified — should not reach here for PLT/GOT
+        return 0;
+    }
 
-        if ((insns[1] & 0xFFC00000) == 0xF9400000) {
-            uint32_t ldr_imm = (insns[1] >> 10) & 0xFFF;
-            uint64_t got_addr = page + (ldr_imm * 8);
-            return (void**)got_addr;
+    ElfW(Addr) base = info->dlpi_addr;
+
+    // Find PT_DYNAMIC segment
+    const ElfW(Dyn)* dyn = NULL;
+    for (int i = 0; i < info->dlpi_phnum; i++) {
+        if (info->dlpi_phdr[i].p_type == PT_DYNAMIC) {
+            dyn = (const ElfW(Dyn)*)(base + info->dlpi_phdr[i].p_vaddr);
+            break;
         }
     }
 
-    LOGE("Could not find GOT entry for function at %p", func_addr);
-    return NULL;
+    if (!dyn) return 0;
+
+    // Extract dynamic entries
+    ElfW(Addr) jmprel_addr = 0;
+    size_t pltrelsz = 0;
+    ElfW(Addr) symtab_addr = 0;
+    ElfW(Addr) strtab_addr = 0;
+
+    for (const ElfW(Dyn)* d = dyn; d->d_tag != DT_NULL; d++) {
+        switch (d->d_tag) {
+            case DT_JMPREL:   jmprel_addr  = d->d_un.d_ptr; break;
+            case DT_PLTRELSZ: pltrelsz     = d->d_un.d_val; break;
+            case DT_SYMTAB:   symtab_addr  = d->d_un.d_ptr; break;
+            case DT_STRTAB:   strtab_addr  = d->d_un.d_ptr; break;
+        }
+    }
+
+    if (!jmprel_addr || !symtab_addr || !strtab_addr || pltrelsz == 0) {
+        return 0;
+    }
+
+    // On Android, d_ptr values may be relative offsets (not relocated by linker).
+    // Detect this: if the value is smaller than the module base, it's relative.
+    if (jmprel_addr < base)  jmprel_addr  += base;
+    if (symtab_addr < base)  symtab_addr  += base;
+    if (strtab_addr < base)  strtab_addr  += base;
+
+    const ElfW(Rela)* jmprel = (const ElfW(Rela)*)jmprel_addr;
+    const ElfW(Sym)* symtab  = (const ElfW(Sym)*)symtab_addr;
+    const char* strtab       = (const char*)strtab_addr;
+
+    size_t rela_count = pltrelsz / sizeof(ElfW(Rela));
+
+    verbose_log("Scanning GOT of %s (%zu relocation entries)", info->dlpi_name, rela_count);
+
+    for (size_t i = 0; i < rela_count; i++) {
+        unsigned long sym_idx = ELF64_R_SYM(jmprel[i].r_info);
+        const char* name = strtab + symtab[sym_idx].st_name;
+
+        if (strcmp(name, ctx->sym_name) == 0) {
+            void** got_addr = (void**)(base + jmprel[i].r_offset);
+
+            LOGI("Found GOT entry for '%s' in %s at %p (current value: %p)",
+                 ctx->sym_name, info->dlpi_name, got_addr, *got_addr);
+
+            if (change_page_protection(got_addr, PROT_READ | PROT_WRITE) != 0) {
+                LOGE("Failed to change GOT page protection for %p", got_addr);
+                continue;
+            }
+
+            int idx = ctx->hook_info->data.plt_got.patched_count;
+            if (idx >= 64) {
+                LOGW("Maximum GOT patches reached (64)");
+                return 1; // Stop iteration
+            }
+
+            // Save original and patch
+            ctx->hook_info->data.plt_got.got_entries[idx] = got_addr;
+            ctx->hook_info->data.plt_got.original_funcs[idx] = *got_addr;
+            if (idx == 0) {
+                ctx->original_func = *got_addr;
+            }
+
+            *got_addr = ctx->hook_func;
+            ctx->hook_info->data.plt_got.patched_count++;
+
+            LOGI("Patched GOT entry at %p: %p -> %p",
+                 got_addr, ctx->hook_info->data.plt_got.original_funcs[idx], ctx->hook_func);
+        }
+    }
+
+    return 0;
 }
 
-int install_plt_got_hook(void* target_func, void* hook_func, HookInfo* hook_info) {
+int install_plt_got_hook(void* target_func, void* hook_func, HookInfo* hook_info, const char* caller_lib) {
     LOGI("Installing PLT/GOT hook: target=%p hook=%p", target_func, hook_func);
 
-    void** got_entry = find_got_entry(target_func);
-    if (!got_entry) {
-        LOGE("Failed to find GOT entry");
+    // Step 1: Resolve symbol name via dladdr
+    Dl_info dl_info;
+    if (!dladdr(target_func, &dl_info) || !dl_info.dli_sname) {
+        LOGE("dladdr failed: cannot resolve symbol name for %p", target_func);
         return -1;
     }
 
-    LOGI("Found GOT entry at %p, current value: %p", got_entry, *got_entry);
+    LOGI("Resolved symbol: %s (from %s)", dl_info.dli_sname, dl_info.dli_fname);
 
-    if (change_page_protection(got_entry, PROT_READ | PROT_WRITE) != 0) {
-        LOGE("Failed to change GOT page protection");
-        return -1;
-    }
-
-    void* original_func = *got_entry;
-
-    *got_entry = hook_func;
-
+    // Step 2: Initialize hook_info for PLT/GOT
     hook_info->type = HOOK_PLT_GOT;
-    hook_info->data.plt_got.got_entry = got_entry;
-    hook_info->data.plt_got.original_func = original_func;
+    hook_info->data.plt_got.patched_count = 0;
     hook_info->data.plt_got.hook_func = hook_func;
 
-    LOGI("PLT/GOT hook installed: GOT entry=%p, original=%p, hook=%p",
-         got_entry, original_func, hook_func);
+    // Step 3: Scan loaded modules for GOT entries matching the symbol
+    struct got_scan_ctx ctx = {
+        .sym_name = dl_info.dli_sname,
+        .caller_lib = caller_lib,
+        .hook_func = hook_func,
+        .hook_info = hook_info,
+        .original_func = NULL
+    };
+
+    dl_iterate_phdr(got_scan_callback, &ctx);
+
+    if (hook_info->data.plt_got.patched_count == 0) {
+        LOGE("No GOT entries found for symbol '%s'", dl_info.dli_sname);
+        return -1;
+    }
+
+    LOGI("PLT/GOT hook installed: %d GOT entries patched for '%s'",
+         hook_info->data.plt_got.patched_count, dl_info.dli_sname);
 
     return 0;
 }
@@ -269,29 +380,31 @@ int uninstall_hook(int hook_id) {
         hook->data.trampoline.trampoline_addr = NULL;
 
     } else if (hook->type == HOOK_PLT_GOT) {
-        if (hook->data.plt_got.got_entry == NULL) {
+        if (hook->data.plt_got.patched_count == 0) {
             LOGI("Hook %d already uninstalled", hook_id);
             return 0;
         }
 
-        void** got_entry = hook->data.plt_got.got_entry;
+        for (int i = 0; i < hook->data.plt_got.patched_count; i++) {
+            void** got_entry = hook->data.plt_got.got_entries[i];
+            if (!got_entry) continue;
 
-        if (change_page_protection(got_entry, PROT_READ | PROT_WRITE) != 0) {
-            LOGE("Failed to change page protection for unhook");
-            return -1;
+            if (change_page_protection(got_entry, PROT_READ | PROT_WRITE) != 0) {
+                LOGE("Failed to change GOT page protection for uninstall (entry %d)", i);
+                continue;
+            }
+
+            *got_entry = hook->data.plt_got.original_funcs[i];
+            __builtin___clear_cache((char*)got_entry, (char*)got_entry + sizeof(void*));
+            hook->data.plt_got.got_entries[i] = NULL;
         }
 
-        *got_entry = hook->data.plt_got.original_func;
+        hook->data.plt_got.patched_count = 0;
 
-        LOGI("Restored GOT entry at %p to %p", got_entry, hook->data.plt_got.original_func);
-
-        hook->data.plt_got.got_entry = NULL;
-        hook->data.plt_got.original_func = NULL;
-    }
-
-    if (hook->thunk_addr) {
-        munmap(hook->thunk_addr, PAGE_SIZE);
-        hook->thunk_addr = NULL;
+        if (hook->thunk_addr) {
+            munmap(hook->thunk_addr, PAGE_SIZE);
+            hook->thunk_addr = NULL;
+        }
     }
 
     if (g_lua_engine && hook->lua_onEnter_ref != LUA_NOREF) {
@@ -322,7 +435,7 @@ int uninstall_all_hooks(void) {
         if (g_hooks[i].type == HOOK_TRAMPOLINE) {
             is_installed = (g_hooks[i].data.trampoline.target_addr != NULL);
         } else if (g_hooks[i].type == HOOK_PLT_GOT) {
-            is_installed = (g_hooks[i].data.plt_got.got_entry != NULL);
+            is_installed = (g_hooks[i].data.plt_got.patched_count > 0);
         }
 
         if (is_installed && uninstall_hook(i) == 0) {
@@ -360,7 +473,7 @@ void* create_hook_thunk(int hook_index) {
     return thunk;
 }
 
-bool install_lua_hook(const char* lib_name, uintptr_t offset, int onEnter_ref, int onLeave_ref) {
+bool install_lua_hook(const char* lib_name, uintptr_t offset, int onEnter_ref, int onLeave_ref, const char* caller_lib) {
     LOGI("Installing Lua hook: %s+0x%lx", lib_name, offset);
 
     uintptr_t base = (uintptr_t)find_library_base(lib_name);
@@ -391,9 +504,9 @@ bool install_lua_hook(const char* lib_name, uintptr_t offset, int onEnter_ref, i
     hook_info->thunk_addr = thunk;
 
     int result = -1;
-    if (g_default_hook_type == HOOK_PLT_GOT) {
-        LOGI("Using PLT/GOT hooking method");
-        result = install_plt_got_hook((void*)target_addr, thunk, hook_info);
+    if (caller_lib && strlen(caller_lib) > 0) {
+        LOGI("Using PLT/GOT hooking method (caller: %s)", caller_lib);
+        result = install_plt_got_hook((void*)target_addr, thunk, hook_info, caller_lib);
     } else {
         LOGI("Using trampoline hooking method");
         result = install_trampoline_hook((void*)target_addr, thunk, hook_info);
@@ -409,7 +522,7 @@ bool install_lua_hook(const char* lib_name, uintptr_t offset, int onEnter_ref, i
 
     LOGI("Lua hook #%d installed (type=%s, onEnter=%d, onLeave=%d)",
          hook_index,
-         g_default_hook_type == HOOK_PLT_GOT ? "PLT/GOT" : "Trampoline",
+         (caller_lib && strlen(caller_lib) > 0) ? "PLT/GOT" : "Trampoline",
          onEnter_ref, onLeave_ref);
     return true;
 }
@@ -609,7 +722,9 @@ void* get_current_trampoline(void) {
         if (hook->type == HOOK_TRAMPOLINE) {
             return hook->data.trampoline.trampoline_addr;
         } else if (hook->type == HOOK_PLT_GOT) {
-            return hook->data.plt_got.original_func;
+            return (hook->data.plt_got.patched_count > 0)
+                ? hook->data.plt_got.original_funcs[0]
+                : NULL;
         }
     }
     return NULL;

--- a/src/agent/include/agent/globals.h
+++ b/src/agent/include/agent/globals.h
@@ -26,7 +26,6 @@ extern JNIEnv* g_current_jni_env;
 
 extern JavaVM* g_java_vm;
 
-extern int g_default_hook_type;
 
 extern bool g_verbose_mode;
 

--- a/src/agent/include/agent/hook.h
+++ b/src/agent/include/agent/hook.h
@@ -21,8 +21,9 @@ typedef struct {
 } TrampolineHook;
 
 typedef struct {
-    void** got_entry;
-    void* original_func;
+    void** got_entries[64];
+    void* original_funcs[64];
+    int patched_count;
     void* hook_func;
 } PltGotHook;
 
@@ -51,10 +52,9 @@ uint32_t create_branch_insn(void* from, void* to);
 void* allocate_trampoline(size_t size);
 size_t disassemble_instructions(void* addr, void** insn_out, size_t min_bytes);
 bool is_pc_relative(void* insn);
-void** find_got_entry(void* func_addr);
 int install_trampoline_hook(void* target_func, void* hook_func, HookInfo* hook_info);
-int install_plt_got_hook(void* target_func, void* hook_func, HookInfo* hook_info);
-bool install_lua_hook(const char* lib_name, uintptr_t offset, int onEnter_ref, int onLeave_ref);
+int install_plt_got_hook(void* target_func, void* hook_func, HookInfo* hook_info, const char* caller_lib);
+bool install_lua_hook(const char* lib_name, uintptr_t offset, int onEnter_ref, int onLeave_ref, const char* caller_lib);
 
 void generic_hook_handler(void);
 void hook_logger(uint64_t* saved_regs);

--- a/src/agent/include/agent/lua_hook.h
+++ b/src/agent/include/agent/lua_hook.h
@@ -34,7 +34,7 @@ typedef struct HookTarget{
 void register_memory_api(lua_State* L);
 
 bool install_lua_hook(const char* lib_name, uintptr_t offset,
-                      int onEnter_ref, int onLeave_ref);
+                      int onEnter_ref, int onLeave_ref, const char* caller_lib);
 
 #ifdef __cplusplus
 }

--- a/src/agent/lua/api_hook.c
+++ b/src/agent/lua/api_hook.c
@@ -58,23 +58,6 @@ static struct HookTarget create_java_target(lua_State* L) {
 static int lua_hook(lua_State* L) {
     struct HookTarget target;
 
-    lua_getglobal(L, "__hook_type__");
-    if (lua_isstring(L, -1)) {
-        const char* hook_type_str = lua_tostring(L, -1);
-        verbose_log("Global hook type detected: %s", hook_type_str);
-
-        if (strcmp(hook_type_str, "pltgot") == 0) {
-            g_default_hook_type = HOOK_PLT_GOT;
-            verbose_log("Hook type set to PLT/GOT");
-        } else if (strcmp(hook_type_str, "trampoline") == 0) {
-            g_default_hook_type = HOOK_TRAMPOLINE;
-            verbose_log("Hook type set to trampoline");
-        } else {
-            verbose_log("Unknown hook type '%s', using default", hook_type_str);
-        }
-    }
-    lua_pop(L, 1);
-
     if (lua_isnumber(L, 2)) {
         target = create_native_target(L);
     } else if (lua_isstring(L, 2)) {
@@ -122,12 +105,56 @@ static int lua_hook(lua_State* L) {
         verbose_log("onLeave callback registered (ref: %d)", onLeave_ref);
     }
 
+    // Parse optional 'caller' field for PLT/GOT targeted hooking
+    // Can be a string (single library) or a table (array of library names)
+    const char* caller_lib = NULL;
+    static char caller_buf[1024];
+    caller_buf[0] = '\0';
+
+    lua_getfield(L, callback_index, "caller");
+    if (lua_isstring(L, -1)) {
+        caller_lib = lua_tostring(L, -1);
+        verbose_log("Caller library specified: %s", caller_lib);
+    } else if (lua_istable(L, -1)) {
+        size_t buf_pos = 0;
+        int len = (int)lua_rawlen(L, -1);
+        for (int i = 1; i <= len; i++) {
+            lua_rawgeti(L, -1, i);
+            if (lua_isstring(L, -1)) {
+                const char* name = lua_tostring(L, -1);
+                if (buf_pos > 0 && buf_pos < sizeof(caller_buf) - 1) {
+                    caller_buf[buf_pos++] = ',';
+                }
+                size_t name_len = strlen(name);
+                if (buf_pos + name_len < sizeof(caller_buf) - 1) {
+                    memcpy(caller_buf + buf_pos, name, name_len);
+                    buf_pos += name_len;
+                }
+            }
+            lua_pop(L, 1);
+        }
+        caller_buf[buf_pos] = '\0';
+        if (buf_pos > 0) {
+            caller_lib = caller_buf;
+            verbose_log("Caller libraries specified: %s", caller_lib);
+        }
+    }
+    lua_pop(L, 1);
+
+    // Auto-detect hook type: caller present = PLT/GOT, absent = trampoline
+    if (caller_lib) {
+        verbose_log("Hook type auto-selected: PLT/GOT (caller=%s)", caller_lib);
+    } else {
+        verbose_log("Hook type auto-selected: Trampoline (no caller)");
+    }
+
     verbose_log("Hook target: type=%d, callbacks registered", target.type);
 
     if (target.type == NATIVE_METHOD) {
         bool result = install_lua_hook(target.info.native.lib_name,
                                        target.info.native.offset,
-                                       onEnter_ref, onLeave_ref);
+                                       onEnter_ref, onLeave_ref,
+                                       caller_lib);
         if (!result) {
             return luaL_error(L, "Failed to install native hook");
         }

--- a/src/agent/proc/proc.c
+++ b/src/agent/proc/proc.c
@@ -518,7 +518,9 @@ elf_exports_t* get_exports(const char* lib_name) {
         unsigned char type = ELF64_ST_TYPE(symtab[i].st_info);
         unsigned char bind = ELF64_ST_BIND(symtab[i].st_info);
 
-        if (type == STT_FUNC && symtab[i].st_value != 0 &&
+        if ((type == STT_FUNC || type == STT_OBJECT || type == STT_NOTYPE || type == STT_GNU_IFUNC) && 
+            symtab[i].st_value != 0 &&
+            symtab[i].st_shndx != SHN_UNDEF &&
             (bind == STB_GLOBAL || bind == STB_WEAK)) {
 
             elf_export_t* exp = &result->exports[result->count];
@@ -643,7 +645,9 @@ elf_exports_t* get_symbols(const char* lib_name) {
     for (size_t i = 0; i < sym_count; i++) {
         unsigned char type = ELF64_ST_TYPE(symtab[i].st_info);
 
-        if (type == STT_FUNC && symtab[i].st_value != 0) {
+        if ((type == STT_FUNC || type == STT_OBJECT || type == STT_NOTYPE || type == STT_GNU_IFUNC) && 
+            symtab[i].st_value != 0 &&
+            symtab[i].st_shndx != SHN_UNDEF) {
             elf_export_t* exp = &result->exports[result->count];
             const char* name = strtab + symtab[i].st_name;
 

--- a/src/binr/renef/main.cpp
+++ b/src/binr/renef/main.cpp
@@ -878,7 +878,6 @@ int main(int argc, char *argv[]) {
     std::string script_file;
     std::string attach_pid;
     std::string spawn_app;
-    std::string hook_type;
     bool view_mode = false;
 
     for (int i = 1; i < argc; i++) {
@@ -895,12 +894,6 @@ int main(int argc, char *argv[]) {
         }
         else if ((arg == "-s" || arg == "--spawn") && i + 1 < argc) {
             spawn_app = argv[++i];
-        }
-        else if (arg == "--hook" && i + 1 < argc) {
-            hook_type = argv[++i];
-        }
-        else if (arg.rfind("--hook=", 0) == 0) {
-            hook_type = arg.substr(7);
         }
         else if ((arg == "-g" || arg == "--gadget") && i + 1 < argc) {
             g_gadget_pid = std::stoi(argv[++i]);
@@ -1058,20 +1051,10 @@ int main(int argc, char *argv[]) {
 
         if (!spawn_app.empty()) {
             start_cmd = "spawn " + spawn_app;
-            if (!hook_type.empty()) {
-                start_cmd += " --hook=" + hook_type;
-                std::cout << "[*] Spawning " << spawn_app << " (hook: " << hook_type << ")...\n";
-            } else {
-                std::cout << "[*] Spawning " << spawn_app << "...\n";
-            }
+            std::cout << "[*] Spawning " << spawn_app << "...\n";
         } else {
             start_cmd = "attach " + attach_pid;
-            if (!hook_type.empty()) {
-                start_cmd += " --hook=" + hook_type;
-                std::cout << "[*] Attaching to PID " << attach_pid << " (hook: " << hook_type << ")...\n";
-            } else {
-                std::cout << "[*] Attaching to PID " << attach_pid << "...\n";
-            }
+            std::cout << "[*] Attaching to PID " << attach_pid << "...\n";
         }
 
         std::string response = send_command(start_cmd);

--- a/src/librenef/cmd/cmd_attach.cpp
+++ b/src/librenef/cmd/cmd_attach.cpp
@@ -28,7 +28,6 @@ static std::string build_adb_cmd_attach(const std::string &cmd) {
 
 struct AttachParams {
   int pid;
-  std::string hook_type;
 };
 
 static AttachParams parse_attach_params(const char *cmd_buffer,
@@ -53,16 +52,11 @@ static AttachParams parse_attach_params(const char *cmd_buffer,
 
   size_t hook_pos = args.find("--hook=");
   if (hook_pos != std::string::npos) {
-    size_t hook_start = hook_pos + 7;
-    size_t hook_end = args.find(' ', hook_start);
-    if (hook_end == std::string::npos) {
-      hook_end = args.length();
-    }
-    params.hook_type = args.substr(hook_start, hook_end - hook_start);
-
+    // Legacy: strip --hook= argument if present (no longer used)
+    size_t hook_end = args.find(' ', hook_pos);
+    if (hook_end == std::string::npos) hook_end = args.length();
     std::string before_hook = args.substr(0, hook_pos);
-    std::string after_hook =
-        (hook_end < args.length()) ? args.substr(hook_end) : "";
+    std::string after_hook = (hook_end < args.length()) ? args.substr(hook_end) : "";
     args = before_hook + after_hook;
   }
 
@@ -139,12 +133,6 @@ public:
           sock.send_data(con_cmd.c_str(), con_cmd.length(), false);
 
       sock.set_session_key(session_key);
-
-      if (!params.hook_type.empty()) {
-        std::string hook_cmd =
-            "exec _G.__hook_type__ = \"" + params.hook_type + "\"\n";
-        sock.send_data(hook_cmd.c_str(), hook_cmd.length(), false);
-      }
     }
 
     const char *response = is_injected ? "OK\n" : "FAIL\n";

--- a/src/librenef/cmd/cmd_spawn.cpp
+++ b/src/librenef/cmd/cmd_spawn.cpp
@@ -16,7 +16,6 @@
 
 struct SpawnParams {
   std::string pkg_name;
-  std::string hook_type;
 };
 
 static SpawnParams parse_spawn_params(const char *cmd_buffer, size_t cmd_size) {
@@ -38,16 +37,11 @@ static SpawnParams parse_spawn_params(const char *cmd_buffer, size_t cmd_size) {
 
   size_t hook_pos = args.find("--hook=");
   if (hook_pos != std::string::npos) {
-    size_t hook_start = hook_pos + 7;
-    size_t hook_end = args.find(' ', hook_start);
-    if (hook_end == std::string::npos) {
-      hook_end = args.length();
-    }
-    params.hook_type = args.substr(hook_start, hook_end - hook_start);
-
+    // Legacy: strip --hook= argument if present (no longer used)
+    size_t hook_end = args.find(' ', hook_pos);
+    if (hook_end == std::string::npos) hook_end = args.length();
     std::string before_hook = args.substr(0, hook_pos);
-    std::string after_hook =
-        (hook_end < args.length()) ? args.substr(hook_end) : "";
+    std::string after_hook = (hook_end < args.length()) ? args.substr(hook_end) : "";
     args = before_hook + after_hook;
   }
 
@@ -92,7 +86,6 @@ public:
     SpawnParams params = parse_spawn_params(cmd_buffer, cmd_size);
 
     std::cerr << "  Package name: '" << params.pkg_name << "'" << std::endl;
-    std::cerr << "  Hook type: '" << params.hook_type << "'" << std::endl;
     std::cerr << "  Raw command: '" << std::string(cmd_buffer, cmd_size) << "'"
               << std::endl;
 
@@ -173,12 +166,6 @@ public:
           sock.send_data(con_cmd.c_str(), con_cmd.length(), false);
 
       sock.set_session_key(session_key);
-
-      if (!params.hook_type.empty()) {
-        std::string hook_cmd =
-            "exec _G.__hook_type__ = \"" + params.hook_type + "\"\n";
-        sock.send_data(hook_cmd.c_str(), hook_cmd.length(), false);
-      }
 
       snprintf(response, sizeof(response), "OK %d\n", pid);
     } else {


### PR DESCRIPTION
Hook type is now auto-detected from the caller parameter:
- caller present → PLT/GOT hooking (patches the caller's GOT)
- caller absent → Inline trampoline hooking (patches the function directly)

Modified Files:
- api_hook.c: Removed `__hook_type__` reading; parses caller as string or table; auto-detects hook type
- native.c: `install_lua_hook` uses caller_lib presence to choose hook type;  `got_scan_callback` supports comma-separated callers
- globals.h: Removed `g_default_hook_type`
- globals.c: Removed `g_default_hook_type`
- cmd_spawn.cpp: Removed `hook_type` field and `__hook_type__` sending
- cmd_attach.cpp: Removed `hook_type` field and `__hook_type__` sending
- main.cpp: Removed --hook CLI argument parsing

Example code snippets:
-- Trampoline (no caller)
hook("libc.so", offset, {
    onEnter = function(args) ... end
})
-- PLT/GOT (single caller)
hook("libc.so", offset, {
    caller = "libcrackme.so",
    onEnter = function(args) ... end
})
-- PLT/GOT (multiple callers)
hook("libc.so", offset, {
    caller = {"libcrackme.so", "libnative.so"},
    onEnter = function(args) ... end
})