### PR TITLE
Strace API added

### DIFF
--- a/scripts/examples/syscall_test.lua
+++ b/scripts/examples/syscall_test.lua
@@ -1,0 +1,173 @@
+-- Syscall Arg Mutation Test
+-- Does not require KCOV - runs directly on device
+-- Usage: spawn <app> -> l scripts/examples/syscall_test.lua
+
+print(CYAN .. "=== Syscall Arg Mutation Test ===" .. RESET)
+
+local pass = 0
+local fail = 0
+
+-----------------------------------------------
+-- Test 1: onCall arg reading (read-only)
+-----------------------------------------------
+print("\n[1] onCall arg read test...")
+
+local captured_args = nil
+Syscall.trace("openat", {
+    onCall = function(info)
+        if info.args[2] and tostring(info.args[2]) ~= "0" then
+            captured_args = {info.args[1], info.args[2], info.args[3]}
+            print(string.format("  args: fd=%d, path=0x%x, flags=0x%x",
+                  info.args[1], info.args[2], info.args[3]))
+        end
+    end
+})
+
+-- trigger
+local f = io.open("/proc/self/maps", "r")
+if f then f:close() end
+
+Syscall.untrace("openat")
+
+if captured_args then
+    print(GREEN .. "  PASS: onCall args read" .. RESET)
+    pass = pass + 1
+else
+    print(RED .. "  FAIL: onCall not triggered" .. RESET)
+    fail = fail + 1
+end
+
+-----------------------------------------------
+-- Test 2: onReturn retval reading
+-----------------------------------------------
+print("\n[2] onReturn retval test...")
+
+local ret_captured = false
+Syscall.trace("openat", {
+    onReturn = function(info)
+        if info.retval and info.retval >= 0 then
+            print(string.format("  retval: %d (fd)", info.retval))
+            ret_captured = true
+        end
+    end
+})
+
+local f2 = io.open("/proc/self/status", "r")
+if f2 then f2:close() end
+
+Syscall.untrace("openat")
+
+if ret_captured then
+    print(GREEN .. "  PASS: onReturn retval read" .. RESET)
+    pass = pass + 1
+else
+    print(RED .. "  FAIL: onReturn not triggered" .. RESET)
+    fail = fail + 1
+end
+
+-----------------------------------------------
+-- Test 3: onReturn retval override
+-----------------------------------------------
+print("\n[3] onReturn retval override test...")
+
+local original_ret = nil
+local override_worked = false
+
+Syscall.trace("access", {
+    onCall = function(info)
+        print("  access() called")
+    end,
+    onReturn = function(info)
+        original_ret = info.retval
+        print(string.format("  original retval: %d", info.retval))
+        -- return 0 to always report "success"
+        return 0
+    end
+})
+
+-- nonexistent file - normally returns -1
+os.execute("test -f /nonexistent_file_xyztmp 2>/dev/null")
+
+Syscall.untrace("access")
+
+-- Note: full verification via os.execute is difficult,
+-- but seeing the callback fire and return is sufficient
+if original_ret ~= nil then
+    print(GREEN .. "  PASS: retval override callback fired" .. RESET)
+    pass = pass + 1
+else
+    print(YELLOW .. "  SKIP: access() not triggered" .. RESET)
+end
+
+-----------------------------------------------
+-- Test 4: skip original
+-----------------------------------------------
+print("\n[4] skip original test...")
+
+local skip_tested = false
+Syscall.trace("access", {
+    onCall = function(info)
+        print("  access() caught, skip=true, retval=-1")
+        info.skip = true
+        info.retval = -1  -- behave like ENOENT
+        skip_tested = true
+    end,
+    onReturn = function(info)
+        print(string.format("  retval after skip: %d", info.retval))
+        return info.retval
+    end
+})
+
+-- this syscall should never reach the kernel
+os.execute("test -f /proc/self/maps 2>/dev/null")
+
+Syscall.untrace("access")
+
+if skip_tested then
+    print(GREEN .. "  PASS: skip original worked" .. RESET)
+    pass = pass + 1
+else
+    print(YELLOW .. "  SKIP: access() not triggered" .. RESET)
+end
+
+-----------------------------------------------
+-- Test 5: arg mutation (ioctl)
+-----------------------------------------------
+print("\n[5] ioctl arg mutation test...")
+
+local ioctl_seen = false
+local mutated = false
+
+Syscall.trace("ioctl", {
+    onCall = function(info)
+        if not ioctl_seen then
+            ioctl_seen = true
+            local orig_cmd = info.args[2]
+            -- modify cmd (just to verify mutation works)
+            -- in real fuzzing you'd assign a random value here
+            info.args[2] = orig_cmd
+            mutated = true
+            print(string.format("  ioctl fd=%d cmd=0x%x -> mutated", info.args[1], orig_cmd))
+        end
+    end
+})
+
+-- wait briefly, ioctl will come naturally (binder etc.)
+-- or trigger one
+local _ = os.clock()
+
+Syscall.untrace("ioctl")
+
+if mutated then
+    print(GREEN .. "  PASS: ioctl arg mutation worked" .. RESET)
+    pass = pass + 1
+else
+    print(YELLOW .. "  SKIP: ioctl not triggered (may be normal)" .. RESET)
+end
+
+-----------------------------------------------
+-- Summary
+-----------------------------------------------
+Syscall.stop()
+
+print(CYAN .. string.format("\n=== Result: %d PASS, %d FAIL ===", pass, fail) .. RESET)

--- a/src/agent/include/agent/strace.h
+++ b/src/agent/include/agent/strace.h
@@ -52,9 +52,10 @@ int strace_remove(const char* syscall_name);
 void strace_remove_all(void);
 
 void strace_hook_handler(void);
-void strace_on_enter(uint64_t* saved_regs);
+int strace_on_enter(uint64_t* saved_regs);
 uint64_t strace_on_return(uint64_t ret_val);
 void* strace_get_original(void);
+uint64_t strace_get_skip_retval(void);
 
 SyscallDef* strace_find_def(const char* name);
 int strace_get_defs_by_category(const char* category, SyscallDef** out, int max);

--- a/src/agent/strace/strace.c
+++ b/src/agent/strace/strace.c
@@ -68,6 +68,7 @@ int g_strace_count = 0;
 static __thread int g_strace_current_index = -1;
 static __thread int g_strace_depth = 0;
 static __thread char g_strace_enter_buf[1024];
+static __thread uint64_t g_strace_skip_retval = 0;
 
 static pthread_mutex_t g_strace_lua_mutex = PTHREAD_MUTEX_INITIALIZER;
 
@@ -224,8 +225,11 @@ void strace_set_current_index(int index) {
     g_strace_current_index = index;
 }
 
-void strace_on_enter(uint64_t* saved_regs) {
-    if (g_strace_depth > 0) return;
+int strace_on_enter(uint64_t* saved_regs) {
+    int skip = 0;
+    g_strace_skip_retval = 0;
+
+    if (g_strace_depth > 0) return 0;
     g_strace_depth++;
 
     g_hook_caller_fp = saved_regs[36];
@@ -234,13 +238,13 @@ void strace_on_enter(uint64_t* saved_regs) {
     int idx = g_strace_current_index;
     if (idx < 0 || idx >= g_strace_count) {
         g_strace_depth--;
-        return;
+        return 0;
     }
 
     StraceEntry* entry = &g_strace_hooks[idx];
     if (!entry->active || !entry->def) {
         g_strace_depth--;
-        return;
+        return 0;
     }
 
     pid_t tid = (pid_t)syscall(SYS_gettid);
@@ -276,7 +280,10 @@ void strace_on_enter(uint64_t* saved_regs) {
         pthread_mutex_lock(&g_strace_lua_mutex);
         lua_State* L = lua_engine_get_state(g_lua_engine);
         if (L) {
+            /* push callback */
             lua_rawgeti(L, LUA_REGISTRYINDEX, entry->lua_onCall_ref);
+
+            /* build info table */
             lua_newtable(L);
 
             lua_pushstring(L, def->name);
@@ -295,10 +302,50 @@ void strace_on_enter(uint64_t* saved_regs) {
             }
             lua_setfield(L, -2, "args");
 
+            /* save ref to info table so we can read back after pcall */
+            lua_pushvalue(L, -1);
+            int info_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+
+            /* pcall: callback(info) -> 0 results */
             if (lua_pcall(L, 1, 0, 0) != LUA_OK) {
                 LOGE("strace onCall callback failed: %s", lua_tostring(L, -1));
                 lua_pop(L, 1);
+            } else {
+                /* read back modified args from info table */
+                lua_rawgeti(L, LUA_REGISTRYINDEX, info_ref);
+
+                lua_getfield(L, -1, "args");
+                if (lua_istable(L, -1)) {
+                    for (int i = 0; i < def->nr_args && i < STRACE_MAX_ARGS; i++) {
+                        lua_rawgeti(L, -1, i + 1);
+                        if (lua_isinteger(L, -1)) {
+                            saved_regs[i] = (uint64_t)lua_tointeger(L, -1);
+                        }
+                        lua_pop(L, 1);
+                    }
+                }
+                lua_pop(L, 1); /* pop args table */
+
+                /* check skip flag */
+                lua_getfield(L, -1, "skip");
+                if (lua_toboolean(L, -1)) {
+                    skip = 1;
+                }
+                lua_pop(L, 1); /* pop skip */
+
+                /* read retval for skip mode */
+                if (skip) {
+                    lua_getfield(L, -1, "retval");
+                    if (lua_isinteger(L, -1)) {
+                        g_strace_skip_retval = (uint64_t)lua_tointeger(L, -1);
+                    }
+                    lua_pop(L, 1); /* pop retval */
+                }
+
+                lua_pop(L, 1); /* pop info table */
             }
+
+            luaL_unref(L, LUA_REGISTRYINDEX, info_ref);
         }
         pthread_mutex_unlock(&g_strace_lua_mutex);
     }
@@ -308,6 +355,7 @@ void strace_on_enter(uint64_t* saved_regs) {
     g_hook_caller_fp = 0;
     g_hook_caller_lr = 0;
     g_strace_depth--;
+    return skip;
 }
 
 uint64_t strace_on_return(uint64_t ret_val) {
@@ -353,8 +401,14 @@ uint64_t strace_on_return(uint64_t ret_val) {
                 lua_setfield(L, -2, "errno_str");
             }
 
-            if (lua_pcall(L, 1, 0, 0) != LUA_OK) {
+            if (lua_pcall(L, 1, 1, 0) != LUA_OK) {
                 LOGE("strace onReturn callback failed: %s", lua_tostring(L, -1));
+                lua_pop(L, 1);
+            } else {
+                /* callback return value overrides retval: integer or nil (no change) */
+                if (lua_isinteger(L, -1)) {
+                    ret_val = (uint64_t)lua_tointeger(L, -1);
+                }
                 lua_pop(L, 1);
             }
         }
@@ -393,6 +447,10 @@ void* strace_get_original(void) {
     return NULL;
 }
 
+uint64_t strace_get_skip_retval(void) {
+    return g_strace_skip_retval;
+}
+
 __attribute__((naked)) void strace_hook_handler(void) {
     __asm__ __volatile__(
         "stp x29, x30, [sp, #-16]!\n"
@@ -420,9 +478,12 @@ __attribute__((naked)) void strace_hook_handler(void) {
         "ldr x0, [sp, #256]\n"
         "bl strace_set_current_index\n"
 
+        /* strace_on_enter returns 0 (normal) or 1 (skip original) */
         "mov x0, sp\n"
         "bl strace_on_enter\n"
+        "cbnz x0, 1f\n"
 
+        /* normal path: call original with (possibly mutated) args */
         "bl strace_get_original\n"
         "str x0, [sp, #264]\n"
 
@@ -434,7 +495,14 @@ __attribute__((naked)) void strace_hook_handler(void) {
 
         "ldr x16, [sp, #264]\n"
         "blr x16\n"
+        "b 2f\n"
 
+        /* skip path: use fake return value instead of calling original */
+        "1:\n"
+        "bl strace_get_skip_retval\n"
+
+        /* common: on_return can still override the return value */
+        "2:\n"
         "bl strace_on_return\n"
 
         "add sp, sp, #288\n"

--- a/src/binr/renef/main.cpp
+++ b/src/binr/renef/main.cpp
@@ -908,6 +908,7 @@ int main(int argc, char *argv[]) {
     std::string attach_pid;
     std::string spawn_app;
     bool view_mode = false;
+    bool watch_mode = false;
 
     for (int i = 1; i < argc; i++) {
         std::string arg = argv[i];
@@ -940,6 +941,9 @@ int main(int argc, char *argv[]) {
                 view_mode = true;
             }
         }
+        else if (arg == "-w" || arg == "--watch") {
+            watch_mode = true;
+        }
         else if (arg == "-v" || arg == "--verbose") {
             g_verbose_mode = true;
         }
@@ -954,10 +958,11 @@ int main(int argc, char *argv[]) {
             std::cout << "  --hook <type>            Hook type: trampoline (default) or pltgot\n";
             std::cout << "  --local                  Local mode: connect via UDS (for Termux/on-device)\n";
             std::cout << "  -m, --mode <mode>        Interface mode: v/view (TUI) [default: CLI]\n";
+            std::cout << "  -w, --watch              Auto-watch hook output after loading script\n";
             std::cout << "  -v, --verbose            Enable verbose mode (show agent debug logs)\n";
             std::cout << "  -h, --help               Show this help\n";
             std::cout << "\nExamples:\n";
-            std::cout << "  " << argv[0] << " -s com.example.app -l script.lua\n";
+            std::cout << "  " << argv[0] << " -s com.example.app -l script.lua -w\n";
             std::cout << "  " << argv[0] << " -s com.example.app --hook pltgot\n";
             std::cout << "  " << argv[0] << " -a 1234 --hook=pltgot -l hook.lua\n";
             std::cout << "  " << argv[0] << " --local -s com.example.app    # On-device usage\n";
@@ -1056,7 +1061,7 @@ int main(int argc, char *argv[]) {
 
     global_commands = registry.get_all_commands_with_descriptions();
 
-    bool auto_started = false;
+    bool auto_started = g_gadget_mode;  // Gadget mode: agent already running
     if (!attach_pid.empty() || !spawn_app.empty()) {
         // Ensure device is connected for CLI spawn/attach
         if (!g_device_ready) {
@@ -1133,6 +1138,11 @@ int main(int argc, char *argv[]) {
             if (!response.empty()) {
             }
             std::cout << "[*] Script loaded\n";
+
+            if (watch_mode) {
+                std::cout << "\n[Auto-watch enabled - Press 'q' to exit]\n";
+                send_command("watch");
+            }
         }
     }
 


### PR DESCRIPTION
## Syscall API Enhancements

### Argument Mutation

Syscall arguments can now be modified in `onCall` callbacks before execution:

```lua
Syscall.trace("ioctl", {
    onCall = function(info)
        info.args[2] = 0x1234  -- replace ioctl command
    end
})
```

### Skip Original Syscall

Prevent the original syscall from reaching the kernel with `info.skip`:

```lua
Syscall.trace("access", {
    onCall = function(info)
        info.skip = true   -- don't execute the real syscall
        info.retval = 0    -- fake return value
    end
})
```

### Return Value Override

Override the syscall return value from `onReturn`:

```lua
Syscall.trace("access", {
    onReturn = function(info)
        if info.retval < 0 then
            return 0  -- force success
        end
    end
})
```

### CLI: `-w` / `--watch` Flag

Auto-watch mode is now available as a CLI argument. After loading a script, Renef automatically streams hook output in real-time:

```bash
./renef -s com.example.app -l hook.lua -w
./renef -g 12345 -l script.lua -w
```

### Gadget Mode: `-l` Script Loading Fix

The `-l` flag now works correctly in gadget mode (`-g`). Previously, scripts passed via `-g <pid> -l script.lua` were silently ignored.
