### PR TITLE
Spawn gate (--pause) added for early hook timing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ add_library(renef_core STATIC
     src/librenef/cmd/cmd_list.cpp
     src/librenef/cmd/cmd_plugin.cpp
     src/librenef/cmd/cmd_strace.cpp
+    src/librenef/cmd/cmd_resume.cpp
 
     # Transport
     src/librenef/transport/uds.cpp

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ SERVER_SRCS := src/server/main.cpp \
                src/librenef/cmd/cmd_memdump.cpp \
                src/librenef/cmd/cmd_hookgen.cpp \
                src/librenef/cmd/cmd_strace.cpp \
+               src/librenef/cmd/cmd_resume.cpp \
                src/librenef/util/string.cpp \
                src/librenef/util/crypto.cpp \
                src/librenef/util/socket.cpp \

--- a/src/binr/renef/main.cpp
+++ b/src/binr/renef/main.cpp
@@ -909,6 +909,7 @@ int main(int argc, char *argv[]) {
     std::string spawn_app;
     bool view_mode = false;
     bool watch_mode = false;
+    bool pause_mode = false;
 
     for (int i = 1; i < argc; i++) {
         std::string arg = argv[i];
@@ -944,6 +945,9 @@ int main(int argc, char *argv[]) {
         else if (arg == "-w" || arg == "--watch") {
             watch_mode = true;
         }
+        else if (arg == "-p" || arg == "--pause") {
+            pause_mode = true;
+        }
         else if (arg == "-v" || arg == "--verbose") {
             g_verbose_mode = true;
         }
@@ -959,6 +963,7 @@ int main(int argc, char *argv[]) {
             std::cout << "  --local                  Local mode: connect via UDS (for Termux/on-device)\n";
             std::cout << "  -m, --mode <mode>        Interface mode: v/view (TUI) [default: CLI]\n";
             std::cout << "  -w, --watch              Auto-watch hook output after loading script\n";
+            std::cout << "  -p, --pause              Freeze app after spawn until script is loaded (spawn gate)\n";
             std::cout << "  -v, --verbose            Enable verbose mode (show agent debug logs)\n";
             std::cout << "  -h, --help               Show this help\n";
             std::cout << "\nExamples:\n";
@@ -1085,7 +1090,8 @@ int main(int argc, char *argv[]) {
 
         if (!spawn_app.empty()) {
             start_cmd = "spawn " + spawn_app;
-            std::cout << "[*] Spawning " << spawn_app << "...\n";
+            if (pause_mode) start_cmd += " --pause";
+            std::cout << "[*] Spawning " << spawn_app << (pause_mode ? " (paused)" : "") << "...\n";
         } else {
             start_cmd = "attach " + attach_pid;
             std::cout << "[*] Attaching to PID " << attach_pid << "...\n";
@@ -1147,6 +1153,9 @@ int main(int argc, char *argv[]) {
     }
 
     if (auto_started) {
+        if (pause_mode && script_file.empty()) {
+            std::cout << "\n[*] Process is paused. Type 'resume' to continue or 'l <script>' to load a script.\n";
+        }
         std::cout << "\n[*] Interactive shell ready\n";
         std::cout << "[*] You can run commands or enter Lua code\n\n";
     }

--- a/src/librenef/cmd/cmd.cpp
+++ b/src/librenef/cmd/cmd.cpp
@@ -38,6 +38,7 @@ std::unique_ptr<CommandDispatcher> create_memdump_command();
 std::unique_ptr<CommandDispatcher> create_hookgen_command();
 std::unique_ptr<CommandDispatcher> create_verbose_command();
 std::unique_ptr<CommandDispatcher> create_strace_command();
+std::unique_ptr<CommandDispatcher> create_resume_command();
 
 void CommandRegistry::register_command(std::unique_ptr<CommandDispatcher> cmd) {
     if (!cmd) {
@@ -136,6 +137,7 @@ void CommandRegistry::setup_all_commands() {
     register_command(create_hookgen_command());
     register_command(create_verbose_command());
     register_command(create_strace_command());
+    register_command(create_resume_command());
 }
 
 bool CommandRegistry::is_command_exist(const std::string& name) {

--- a/src/librenef/cmd/cmd_eval.cpp
+++ b/src/librenef/cmd/cmd_eval.cpp
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <cstring>
+#include <signal.h>
 
 class Eval : public CommandDispatcher {
 public:
@@ -49,6 +50,17 @@ public:
         fprintf(stderr, "[DEBUG exec] Sending %zu bytes to agent\n", command.length());
         ssize_t sent = socket_helper.send_data(command.c_str(), command.length());
         fprintf(stderr, "[DEBUG exec] Actually sent %zd bytes\n", sent);
+
+        // Spawn gate: if process was frozen by spawn, resume it now.
+        // The exec data is already buffered in the kernel socket buffer,
+        // so the agent will read and install hooks before the main thread
+        // reaches onCreate.
+        int gated = CommandRegistry::instance().gated_pid;
+        if (gated > 0 && gated == pid) {
+            fprintf(stderr, "[spawn-gate] Resuming gated process (pid=%d)\n", gated);
+            kill(gated, SIGCONT);
+            CommandRegistry::instance().gated_pid = -1;
+        }
 
         int flags = fcntl(sock, F_GETFL, 0);
         fcntl(sock, F_SETFL, flags | O_NONBLOCK);

--- a/src/librenef/cmd/cmd_load.cpp
+++ b/src/librenef/cmd/cmd_load.cpp
@@ -10,6 +10,7 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <sys/socket.h>
+#include <signal.h>
 
 static std::string read_file(const char* path) {
     FILE* f = fopen(path, "rb");
@@ -69,6 +70,14 @@ public:
         std::string hex = hex_encode(lua_script);
         std::string command = "hexexec " + hex + "\n";
         socket_helper.send_data(command.c_str(), command.length());
+
+        // Spawn gate: resume frozen process after script data is buffered
+        int gated = CommandRegistry::instance().gated_pid;
+        if (gated > 0 && gated == pid) {
+            fprintf(stderr, "[spawn-gate] Resuming gated process (pid=%d)\n", gated);
+            kill(gated, SIGCONT);
+            CommandRegistry::instance().gated_pid = -1;
+        }
 
         int flags = fcntl(sock, F_GETFL, 0);
         fcntl(sock, F_SETFL, flags | O_NONBLOCK);

--- a/src/librenef/cmd/cmd_resume.cpp
+++ b/src/librenef/cmd/cmd_resume.cpp
@@ -1,0 +1,39 @@
+#include <renef/cmd.h>
+#include <cstdio>
+#include <cstring>
+#include <unistd.h>
+#include <signal.h>
+
+class ResumeCommand : public CommandDispatcher {
+public:
+  std::string get_name() const override { return "resume"; }
+
+  std::string get_description() const override {
+    return "Resume a spawn-gated process.";
+  }
+
+  CommandResult dispatch(int client_fd, const char *cmd_buffer,
+                         size_t cmd_size) override {
+    int gated = CommandRegistry::instance().gated_pid;
+
+    if (gated <= 0) {
+      const char *msg = "No gated process.\n";
+      write(client_fd, msg, strlen(msg));
+      return CommandResult(true, "No gated process");
+    }
+
+    kill(gated, SIGCONT);
+    CommandRegistry::instance().gated_pid = -1;
+
+    char msg[128];
+    snprintf(msg, sizeof(msg), "Resumed pid %d\n", gated);
+    write(client_fd, msg, strlen(msg));
+    fprintf(stderr, "[spawn-gate] Manual resume (pid=%d)\n", gated);
+
+    return CommandResult(true, "Resumed");
+  }
+};
+
+std::unique_ptr<CommandDispatcher> create_resume_command() {
+  return std::make_unique<ResumeCommand>();
+}

--- a/src/librenef/cmd/cmd_spawn.cpp
+++ b/src/librenef/cmd/cmd_spawn.cpp
@@ -11,11 +11,13 @@
 #include <unistd.h>
 #include <vector>
 #include <chrono>
+#include <signal.h>
 
 #define RENEF_PAYLOAD_PATH "/data/local/tmp/libagent.so"
 
 struct SpawnParams {
   std::string pkg_name;
+  bool pause = false;
 };
 
 static SpawnParams parse_spawn_params(const char *cmd_buffer, size_t cmd_size) {
@@ -61,6 +63,11 @@ static SpawnParams parse_spawn_params(const char *cmd_buffer, size_t cmd_size) {
   };
   remove_flag("--verbose");
   remove_flag("-v");
+
+  if (args.find("--pause") != std::string::npos) {
+    params.pause = true;
+    remove_flag("--pause");
+  }
 
   size_t start = args.find_first_not_of(" \t");
   size_t end = args.find_last_not_of(" \t");
@@ -166,6 +173,18 @@ public:
           sock.send_data(con_cmd.c_str(), con_cmd.length(), false);
 
       sock.set_session_key(session_key);
+
+      if (params.pause) {
+        // Spawn gate: freeze process AFTER agent is connected.
+        // The agent socket is open and buffered by kernel.
+        // Next exec command will SIGCONT before polling for response,
+        // so the agent reads buffered script data and installs hooks
+        // before the main thread reaches onCreate.
+        kill(pid, SIGSTOP);
+        CommandRegistry::instance().gated_pid = pid;
+        std::cerr << "  [spawn-gate] process frozen (pid=" << pid
+                  << "), will resume on first exec" << std::endl;
+      }
 
       snprintf(response, sizeof(response), "OK %d\n", pid);
     } else {

--- a/src/librenef/include/renef/cmd.h
+++ b/src/librenef/include/renef/cmd.h
@@ -51,6 +51,7 @@ public:
 
 
     int current_pid = -1;
+    int gated_pid = -1;  // PID that is SIGSTOP'd waiting for first exec
     SocketHelper sock;
 
     int get_current_pid() const;


### PR DESCRIPTION
Adds **--pause** flag to spawn mode that freezes the target process (_SIGSTOP_) after agent injection, allowing hooks to be installed before app initialization (e.g. root detection in onCreate). Process resumes (_SIGCONT_) automatically when a script is loaded,or manually via the new 'resume' command.


<img width="722" height="434" alt="image" src="https://github.com/user-attachments/assets/e8a57904-c4f1-4834-8c90-4cccc7907c66" />
