### PR TITLE
Pause mode changed with ptrace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ add_library(renef_core STATIC
 
     # Injector
     src/inject/injector.cpp
+    src/inject/ptrace_injector.cpp
 
     # Plugin system
     src/librenef/plugin/plugin.cpp

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,8 @@ SERVER_SRCS := src/server/main.cpp \
                src/librenef/util/string.cpp \
                src/librenef/util/crypto.cpp \
                src/librenef/util/socket.cpp \
-               src/inject/injector.cpp
+               src/inject/injector.cpp \
+               src/inject/ptrace_injector.cpp
 
 SERVER_CXXFLAGS := -std=c++17 \
                    $(SERVER_OPT_FLAGS) \
@@ -412,6 +413,8 @@ CLIENT_ANDROID_SRCS := src/binr/renef/main.cpp \
                        src/librenef/cmd/cmd_memdump.cpp \
                        src/librenef/cmd/cmd_hookgen.cpp \
                        src/librenef/cmd/cmd_strace.cpp \
+                       src/librenef/cmd/cmd_resume.cpp \
+                       src/librenef/cmd/cmd_ai.cpp \
                        src/librenef/cmd/cmd_plugin.cpp \
                        src/librenef/transport/server.cpp \
                        src/librenef/transport/uds.cpp \
@@ -422,7 +425,8 @@ CLIENT_ANDROID_SRCS := src/binr/renef/main.cpp \
                        src/librenef/util/server_connection.cpp \
                        src/librenef/plugin/plugin.cpp \
                        src/librenef/binding/renef.cpp \
-                       src/inject/injector.cpp
+                       src/inject/injector.cpp \
+                       src/inject/ptrace_injector.cpp
 
 CLIENT_ANDROID_CXXFLAGS := -std=c++17 \
                            $(SERVER_OPT_FLAGS) \

--- a/src/agent/hook/native.c
+++ b/src/agent/hook/native.c
@@ -9,10 +9,16 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <pthread.h>
+#include <sched.h>
 #include <dlfcn.h>
 #include <link.h>
 #include <elf.h>
 #include <capstone/capstone.h>
+
+// Reentrancy guard: prevents infinite recursion when a hooked function
+// (e.g. __android_log_print, strlen, fopen) is called from inside the
+// hook handler itself (via LOGI, verbose_log, etc.)
+static __thread int g_hook_reentrant = 0;
 #include <capstone/arm64.h>
 
 HookInfo g_hooks[MAX_HOOKS];
@@ -498,13 +504,118 @@ void* create_hook_thunk(int hook_index) {
     return thunk;
 }
 
+// ============================================================
+// Deferred hooks: installed automatically when a library loads
+// ============================================================
+
+typedef struct {
+    char lib_name[128];
+    uintptr_t offset;
+    int onEnter_ref;
+    int onLeave_ref;
+    char caller_lib[128];
+    bool active;
+} PendingHook;
+
+#define MAX_PENDING_HOOKS 16
+static PendingHook g_pending_hooks[MAX_PENDING_HOOKS];
+static int g_pending_hook_count = 0;
+static bool g_dlopen_hooked = false;
+
+static void try_install_pending_hooks(void);
+
+static void* deferred_poll_thread(void* arg) {
+    (void)arg;
+    LOGI("[deferred] Poll thread started (busy-wait for lib load)");
+
+    // Busy-wait poll: no sleep between iterations. Maximizes chances of
+    // installing the hook between dlopen() returning and the first call
+    // to the hooked function. sched_yield() lets other threads run but
+    // we resume polling as soon as the scheduler gives us CPU.
+    while (1) {
+        bool all_done = true;
+        for (int i = 0; i < g_pending_hook_count; i++) {
+            if (g_pending_hooks[i].active) {
+                all_done = false;
+                break;
+            }
+        }
+        if (all_done) break;
+
+        try_install_pending_hooks();
+        sched_yield(); // give other threads a chance, but no sleep
+    }
+
+    LOGI("[deferred] All pending hooks installed, poll thread exiting");
+    return NULL;
+}
+
+static void start_deferred_poll(void) {
+    if (g_dlopen_hooked) return;
+    g_dlopen_hooked = true;
+
+    pthread_t tid;
+    pthread_create(&tid, NULL, deferred_poll_thread, NULL);
+    pthread_detach(tid);
+    LOGI("[deferred] Started library load watcher (busy-wait)");
+}
+
+static void try_install_pending_hooks(void) {
+    for (int i = 0; i < g_pending_hook_count; i++) {
+        PendingHook* ph = &g_pending_hooks[i];
+        if (!ph->active) continue;
+
+        uintptr_t base = (uintptr_t)find_library_base(ph->lib_name);
+        if (base == 0) continue;
+
+        LOGI("[deferred] Library %s now loaded at 0x%lx, installing hook at +0x%lx",
+             ph->lib_name, base, ph->offset);
+
+        // Install the hook now
+        ph->active = false;
+        install_lua_hook(ph->lib_name, ph->offset,
+                        ph->onEnter_ref, ph->onLeave_ref,
+                        ph->caller_lib[0] ? ph->caller_lib : NULL);
+    }
+}
+
+static bool add_pending_hook(const char* lib_name, uintptr_t offset,
+                             int onEnter_ref, int onLeave_ref,
+                             const char* caller_lib) {
+    if (g_pending_hook_count >= MAX_PENDING_HOOKS) {
+        LOGE("[deferred] Maximum pending hooks reached");
+        return false;
+    }
+
+    PendingHook* ph = &g_pending_hooks[g_pending_hook_count++];
+    strncpy(ph->lib_name, lib_name, sizeof(ph->lib_name) - 1);
+    ph->offset = offset;
+    ph->onEnter_ref = onEnter_ref;
+    ph->onLeave_ref = onLeave_ref;
+    if (caller_lib) {
+        strncpy(ph->caller_lib, caller_lib, sizeof(ph->caller_lib) - 1);
+    } else {
+        ph->caller_lib[0] = '\0';
+    }
+    ph->active = true;
+
+    // Start polling for library loads
+    start_deferred_poll();
+
+    LOGI("[deferred] Pending hook registered: %s+0x%lx (will install on load)",
+         lib_name, offset);
+    return true;
+}
+
+// ============================================================
+
 bool install_lua_hook(const char* lib_name, uintptr_t offset, int onEnter_ref, int onLeave_ref, const char* caller_lib) {
     LOGI("Installing Lua hook: %s+0x%lx", lib_name, offset);
 
     uintptr_t base = (uintptr_t)find_library_base(lib_name);
     if (base == 0) {
-        LOGE("Library not found: %s", lib_name);
-        return false;
+        LOGI("Library %s not loaded yet, deferring hook", lib_name);
+        return add_pending_hook(lib_name, offset, onEnter_ref, onLeave_ref, caller_lib);
     }
 
     uintptr_t target_addr = base + offset;
@@ -552,14 +663,27 @@ bool install_lua_hook(const char* lib_name, uintptr_t offset, int onEnter_ref, i
     return true;
 }
 
+// Check reentrancy and return trampoline address for bypass.
+// Returns NULL if not reentrant (normal path), or trampoline addr to skip handler.
+void* check_hook_reentrant(int hook_index) {
+    if (g_hook_reentrant) {
+        // Reentrant: return trampoline so handler can be bypassed
+        g_current_hook_index = hook_index;
+        return get_current_trampoline();
+    }
+    g_hook_reentrant = 1;
+    return NULL;
+}
+
 __attribute__((naked)) void generic_hook_handler(void) {
     __asm__ __volatile__(
         "stp x29, x30, [sp, #-16]!\n"
         "mov x29, sp\n"
-        "sub sp, sp, #288\n"  
+        "sub sp, sp, #288\n"
 
         "str x17, [sp, #256]\n"
 
+        // Save all regs FIRST (before any C call)
         "stp x0, x1, [sp, #0]\n"
         "stp x2, x3, [sp, #16]\n"
         "stp x4, x5, [sp, #32]\n"
@@ -576,6 +700,12 @@ __attribute__((naked)) void generic_hook_handler(void) {
         "stp x26, x27, [sp, #208]\n"
         "stp x28, xzr, [sp, #224]\n"
 
+        // Check reentrancy BEFORE any logging
+        "ldr x0, [sp, #256]\n"       // x0 = hook_index
+        "bl check_hook_reentrant\n"
+        "cbnz x0, .Lreentrant_bypass\n" // if non-NULL, skip handler
+
+        // Normal path: run hook handler
         "ldr x0, [sp, #256]\n"
         "bl set_current_hook_index\n"
 
@@ -583,7 +713,7 @@ __attribute__((naked)) void generic_hook_handler(void) {
         "bl hook_logger\n"
 
         "bl get_current_trampoline\n"
-        "str x0, [sp, #264]\n"  
+        "str x0, [sp, #264]\n"
 
         "ldp x0, x1, [sp, #0]\n"
         "ldp x2, x3, [sp, #16]\n"
@@ -600,12 +730,27 @@ __attribute__((naked)) void generic_hook_handler(void) {
         "add sp, sp, #288\n"
         "ldp x29, x30, [sp], #16\n"
         "ret\n"
+
+        // Reentrant bypass: skip handler, go straight to trampoline
+        ".Lreentrant_bypass:\n"
+        "str x0, [sp, #264]\n"       // store trampoline addr
+
+        "ldp x0, x1, [sp, #0]\n"
+        "ldp x2, x3, [sp, #16]\n"
+        "ldp x4, x5, [sp, #32]\n"
+        "ldp x6, x7, [sp, #48]\n"
+        "ldp x8, x9, [sp, #64]\n"
+
+        "ldr x16, [sp, #264]\n"
+
+        "add sp, sp, #288\n"
+        "ldp x29, x30, [sp], #16\n"
+        "br x16\n"                    // tail-call trampoline (no blr — don't return here)
     );
 }
 
 void set_current_hook_index(int index) {
     g_current_hook_index = index;
-    LOGI("Set current hook index to %d", index);
 }
 
 void hook_logger(uint64_t* saved_regs) {
@@ -687,6 +832,7 @@ void hook_logger(uint64_t* saved_regs) {
 
     g_hook_caller_fp = 0;
     g_hook_caller_lr = 0;
+    // Note: don't reset g_hook_reentrant here — log_return_value still needs it
 }
 
 uint64_t log_return_value(uint64_t ret_val) {
@@ -752,6 +898,7 @@ uint64_t log_return_value(uint64_t ret_val) {
 
     g_hook_caller_fp = 0;
     g_hook_caller_lr = 0;
+    g_hook_reentrant = 0;  // Reset guard at the very end of hook processing
     return ret_val;
 }
 

--- a/src/binr/renef/main.cpp
+++ b/src/binr/renef/main.cpp
@@ -845,8 +845,12 @@ std::string send_command(const std::string& command) {
         }
     }
 
-    // Drain any stale data from previous streaming commands (strace, watch, etc.)
-    {
+    bool streaming = is_streaming_command(command);
+
+    // Drain any stale data from previous commands — but NOT when starting
+    // a streaming command (watch/strace). Hook output may arrive between
+    // script execution and watch startup; draining would lose it.
+    if (!streaming) {
         int fd = conn.get_socket_fd();
         if (fd >= 0) {
             char drain[4096];
@@ -857,7 +861,6 @@ std::string send_command(const std::string& command) {
         }
     }
 
-    bool streaming = is_streaming_command(command);
     if (streaming) {
         std::cout << "(Press 'q' to exit watch mode)\n";
     }

--- a/src/inject/injector.cpp
+++ b/src/inject/injector.cpp
@@ -487,10 +487,28 @@ bool inject(int pid, const char *so_path) {
     int timeout_counter = 0;
     const int MAX_TIMEOUT = 30000;
 
+    // Try multiple signals to maximize chance of hitting malloc:
+    // SIGUSR1 (10): ART GC trigger — works for app processes
+    // SIGQUIT (3):  ART thread dump — calls malloc heavily, works for Zygote
     char kill_cmd[256];
     snprintf(kill_cmd, sizeof(kill_cmd), "kill -10 %d 2>/dev/null", pid);
     system(kill_cmd);
     std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    snprintf(kill_cmd, sizeof(kill_cmd), "kill -3 %d 2>/dev/null", pid);
+    system(kill_cmd);
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+    // If target is Zygote (has only 1 thread and is in ppoll), launch a cold
+    // app in parallel to force Zygote to process a fork request and call malloc.
+    char check_cmd[256];
+    snprintf(check_cmd, sizeof(check_cmd),
+             "cat /proc/%d/status 2>/dev/null | grep -q 'Threads:\\s*1' && "
+             "cat /proc/%d/comm 2>/dev/null | grep -q zygote", pid, pid);
+    if (system(check_cmd) == 0) {
+      std::cout << "  → Target is Zygote, forcing fork via monkey...\n";
+      // Launch any app via monkey to force Zygote to fork (and call malloc)
+      system("monkey -p com.google.android.contacts 1 >/dev/null 2>&1 &");
+    }
     std::cout << "  → Trigger signals sent\n";
 
     bool dlopen_ok = false;

--- a/src/inject/ptrace_injector.cpp
+++ b/src/inject/ptrace_injector.cpp
@@ -220,14 +220,7 @@ bool ptrace_inject(int pid, const char *so_path) {
     fprintf(stderr, "[ptrace-inject] linker64: %s @ 0x%lx\n", linker_disk_path, linker_base);
     fprintf(stderr, "[ptrace-inject] __loader_dlopen @ 0x%lx\n", dlopen_addr);
 
-    // Find libc base to use as fake caller_addr (for namespace check)
-    uintptr_t libc_base = find_library_base(pid, "libc.so");
-    if (!libc_base) {
-        fprintf(stderr, "[ptrace-inject] libc.so not found in target\n");
-        ptrace(PTRACE_DETACH, pid, 0, 0);
-        return false;
-    }
-    uintptr_t caller_addr = libc_base + 0x1000; // any address inside libc
+    uintptr_t caller_addr = linker_base + 0x1000;
 
     // Save original regs
     arm64_regs orig_regs;

--- a/src/inject/ptrace_injector.cpp
+++ b/src/inject/ptrace_injector.cpp
@@ -1,0 +1,296 @@
+// Ptrace-based injector for spawn gate (--pause) only.
+// This is intentionally separate from the normal signal-based injector.
+// Normal injection stays ptrace-free — only --pause uses this to freeze
+// the target app before onCreate runs.
+//
+// Flow:
+//   1. PTRACE_ATTACH → main thread stops
+//   2. Save registers
+//   3. Find dlopen + libc base + path scratch space
+//   4. Write path string to a RW page
+//   5. Set up x0=path, x1=RTLD_NOW, LR=0, PC=dlopen
+//   6. PTRACE_CONT → dlopen runs
+//   7. Wait for SIGSEGV (return to LR=0)
+//   8. Restore registers
+//   9. PTRACE_DETACH (or keep attached if we want to stay paused)
+//
+// On success the agent is loaded but the main thread is still stopped (if
+// we chose to re-stop). Caller connects to the agent's socket, loads the
+// script, then calls ptrace_resume() to detach.
+
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <sys/ptrace.h>
+#include <sys/uio.h>
+#include <sys/user.h>
+#include <sys/wait.h>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+#include <linux/elf.h>
+
+// user_regs_struct for ARM64
+struct arm64_regs {
+    uint64_t x[31];  // x0-x30
+    uint64_t sp;
+    uint64_t pc;
+    uint64_t pstate;
+};
+
+// From the existing signal-based injector (injector.cpp)
+extern uintptr_t find_library_base(int pid, const char *name);
+extern uintptr_t find_symbol(const char *lib_path, const char *sym);
+extern bool write_memory(int pid, uintptr_t addr, const std::vector<uint8_t> &data);
+extern std::vector<uint8_t> read_memory(int pid, uintptr_t addr, size_t size);
+
+static bool ptrace_get_regs(int pid, arm64_regs *regs) {
+    struct iovec iov = {regs, sizeof(*regs)};
+    if (ptrace(PTRACE_GETREGSET, pid, (void*)NT_PRSTATUS, &iov) < 0) {
+        fprintf(stderr, "[ptrace] GETREGSET failed: %s\n", strerror(errno));
+        return false;
+    }
+    return true;
+}
+
+static bool ptrace_set_regs(int pid, const arm64_regs *regs) {
+    struct iovec iov = {(void*)regs, sizeof(*regs)};
+    if (ptrace(PTRACE_SETREGSET, pid, (void*)NT_PRSTATUS, &iov) < 0) {
+        fprintf(stderr, "[ptrace] SETREGSET failed: %s\n", strerror(errno));
+        return false;
+    }
+    return true;
+}
+
+static bool ptrace_attach_and_wait(int pid) {
+    if (ptrace(PTRACE_ATTACH, pid, 0, 0) < 0) {
+        fprintf(stderr, "[ptrace] ATTACH failed: %s\n", strerror(errno));
+        return false;
+    }
+    int status;
+    if (waitpid(pid, &status, 0) < 0) {
+        fprintf(stderr, "[ptrace] waitpid after attach failed: %s\n", strerror(errno));
+        return false;
+    }
+    if (!WIFSTOPPED(status)) {
+        fprintf(stderr, "[ptrace] target did not stop after attach\n");
+        return false;
+    }
+    return true;
+}
+
+// Run code with modified regs until the target stops (expected via SIGSEGV on LR=0)
+// Returns the stopped-state registers.
+static bool ptrace_call_function(int pid, arm64_regs *saved_regs_out,
+                                 uintptr_t func_addr, uintptr_t x0, uintptr_t x1,
+                                 uintptr_t x2 = 0) {
+    arm64_regs regs, orig_regs;
+    if (!ptrace_get_regs(pid, &orig_regs)) return false;
+    *saved_regs_out = orig_regs;
+
+    regs = orig_regs;
+    regs.x[0] = x0;
+    regs.x[1] = x1;
+    regs.x[2] = x2;
+    regs.x[30] = 0; // LR = 0 → SIGSEGV on return
+    regs.pc = func_addr;
+    // 16-byte align sp
+    regs.sp = (orig_regs.sp - 256) & ~0xFULL;
+
+    if (!ptrace_set_regs(pid, &regs)) return false;
+
+    if (ptrace(PTRACE_CONT, pid, 0, 0) < 0) {
+        fprintf(stderr, "[ptrace] CONT failed: %s\n", strerror(errno));
+        return false;
+    }
+
+    int status;
+    if (waitpid(pid, &status, 0) < 0) {
+        fprintf(stderr, "[ptrace] waitpid after CONT failed: %s\n", strerror(errno));
+        return false;
+    }
+
+    if (!WIFSTOPPED(status)) {
+        fprintf(stderr, "[ptrace] target not stopped after call (status=%d)\n", status);
+        return false;
+    }
+
+    int sig = WSTOPSIG(status);
+    if (sig != SIGSEGV && sig != SIGBUS) {
+        fprintf(stderr, "[ptrace] unexpected signal after call: %d\n", sig);
+    }
+    return true;
+}
+
+bool ptrace_inject(int pid, const char *so_path) {
+    fprintf(stderr, "[ptrace-inject] target pid=%d path=%s\n", pid, so_path);
+
+    if (!ptrace_attach_and_wait(pid)) return false;
+    fprintf(stderr, "[ptrace-inject] attached, target stopped\n");
+
+    // Find dlopen address
+    uintptr_t libdl_base = find_library_base(pid, "libdl.so");
+    if (!libdl_base) {
+        fprintf(stderr, "[ptrace-inject] libdl.so not found in target\n");
+        ptrace(PTRACE_DETACH, pid, 0, 0);
+        return false;
+    }
+
+    // Read /proc/<pid>/maps to find libdl's on-disk path
+    char maps_path[64];
+    snprintf(maps_path, sizeof(maps_path), "/proc/%d/maps", pid);
+    FILE *f = fopen(maps_path, "r");
+    if (!f) {
+        fprintf(stderr, "[ptrace-inject] cannot read /proc/%d/maps\n", pid);
+        ptrace(PTRACE_DETACH, pid, 0, 0);
+        return false;
+    }
+    char line[512];
+    char libdl_disk_path[256] = "";
+    while (fgets(line, sizeof(line), f)) {
+        if (strstr(line, "libdl.so") && strstr(line, "r--p")) {
+            char *p = strrchr(line, '/');
+            if (p) {
+                // Copy from first '/' of path
+                const char *path_start = strchr(line, '/');
+                if (path_start) {
+                    size_t len = strlen(path_start);
+                    while (len > 0 && (path_start[len-1] == '\n' || path_start[len-1] == ' '))
+                        len--;
+                    if (len < sizeof(libdl_disk_path)) {
+                        memcpy(libdl_disk_path, path_start, len);
+                        libdl_disk_path[len] = 0;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    fclose(f);
+
+    if (libdl_disk_path[0] == 0) {
+        fprintf(stderr, "[ptrace-inject] could not resolve libdl.so path\n");
+        ptrace(PTRACE_DETACH, pid, 0, 0);
+        return false;
+    }
+    fprintf(stderr, "[ptrace-inject] libdl: %s @ 0x%lx\n", libdl_disk_path, libdl_base);
+
+    // Use __loader_dlopen from linker64 to bypass namespace check.
+    // Signature: void* __loader_dlopen(const char* filename, int flags, const void* caller_addr);
+    // Find linker64 base in target process
+    rewind(f);
+    f = fopen(maps_path, "r");
+    uintptr_t linker_base = 0;
+    char linker_disk_path[256] = "";
+    while (f && fgets(line, sizeof(line), f)) {
+        if (strstr(line, "linker64") && strstr(line, "r--p")) {
+            uintptr_t start;
+            if (sscanf(line, "%lx-", &start) == 1 && linker_base == 0) {
+                linker_base = start;
+                const char* path_start = strchr(line, '/');
+                if (path_start) {
+                    size_t len = strlen(path_start);
+                    while (len > 0 && (path_start[len-1] == '\n' || path_start[len-1] == ' '))
+                        len--;
+                    if (len < sizeof(linker_disk_path)) {
+                        memcpy(linker_disk_path, path_start, len);
+                        linker_disk_path[len] = 0;
+                    }
+                }
+                break;
+            }
+        }
+    }
+    if (f) fclose(f);
+    if (!linker_base || !linker_disk_path[0]) {
+        fprintf(stderr, "[ptrace-inject] linker64 not found in target maps\n");
+        ptrace(PTRACE_DETACH, pid, 0, 0);
+        return false;
+    }
+    uintptr_t loader_dlopen_offset = find_symbol(linker_disk_path, "__loader_dlopen");
+    if (!loader_dlopen_offset) {
+        fprintf(stderr, "[ptrace-inject] __loader_dlopen not found in linker64\n");
+        ptrace(PTRACE_DETACH, pid, 0, 0);
+        return false;
+    }
+    uintptr_t dlopen_addr = linker_base + loader_dlopen_offset;
+    fprintf(stderr, "[ptrace-inject] linker64: %s @ 0x%lx\n", linker_disk_path, linker_base);
+    fprintf(stderr, "[ptrace-inject] __loader_dlopen @ 0x%lx\n", dlopen_addr);
+
+    // Find libc base to use as fake caller_addr (for namespace check)
+    uintptr_t libc_base = find_library_base(pid, "libc.so");
+    if (!libc_base) {
+        fprintf(stderr, "[ptrace-inject] libc.so not found in target\n");
+        ptrace(PTRACE_DETACH, pid, 0, 0);
+        return false;
+    }
+    uintptr_t caller_addr = libc_base + 0x1000; // any address inside libc
+
+    // Save original regs
+    arm64_regs orig_regs;
+    if (!ptrace_get_regs(pid, &orig_regs)) {
+        ptrace(PTRACE_DETACH, pid, 0, 0);
+        return false;
+    }
+
+    // Write path to target's stack (below current sp)
+    size_t path_len = strlen(so_path) + 1;
+    uintptr_t path_addr = (orig_regs.sp - 512) & ~0xFULL;
+    std::vector<uint8_t> path_bytes(so_path, so_path + path_len);
+    if (!write_memory(pid, path_addr, path_bytes)) {
+        fprintf(stderr, "[ptrace-inject] failed to write path to target stack\n");
+        ptrace_set_regs(pid, &orig_regs);
+        ptrace(PTRACE_DETACH, pid, 0, 0);
+        return false;
+    }
+
+    // Call __loader_dlopen(path, RTLD_NOW=2, caller_addr=libc)
+    arm64_regs saved_regs;
+    if (!ptrace_call_function(pid, &saved_regs, dlopen_addr, path_addr, 2, caller_addr)) {
+        fprintf(stderr, "[ptrace-inject] dlopen call failed\n");
+        ptrace_set_regs(pid, &orig_regs);
+        ptrace(PTRACE_DETACH, pid, 0, 0);
+        return false;
+    }
+
+    // Read return value (dlopen handle) from x0
+    arm64_regs ret_regs;
+    if (!ptrace_get_regs(pid, &ret_regs)) {
+        ptrace_set_regs(pid, &orig_regs);
+        ptrace(PTRACE_DETACH, pid, 0, 0);
+        return false;
+    }
+    uint64_t handle = ret_regs.x[0];
+    fprintf(stderr, "[ptrace-inject] dlopen returned 0x%lx\n", handle);
+
+    // Restore original registers
+    if (!ptrace_set_regs(pid, &orig_regs)) {
+        ptrace(PTRACE_DETACH, pid, 0, 0);
+        return false;
+    }
+
+    // Verify library is loaded
+    uintptr_t agent_base = find_library_base(pid, "libagent.so");
+    if (!agent_base) {
+        fprintf(stderr, "[ptrace-inject] libagent.so NOT found in target maps\n");
+        ptrace(PTRACE_DETACH, pid, 0, 0);
+        return false;
+    }
+    fprintf(stderr, "[ptrace-inject] libagent.so @ 0x%lx\n", agent_base);
+
+    // Note: target is STILL STOPPED here. Caller must call ptrace_resume() later.
+    fprintf(stderr, "[ptrace-inject] success, target still stopped\n");
+    return true;
+}
+
+bool ptrace_resume(int pid) {
+    if (ptrace(PTRACE_DETACH, pid, 0, 0) < 0) {
+        fprintf(stderr, "[ptrace-inject] DETACH failed: %s\n", strerror(errno));
+        return false;
+    }
+    fprintf(stderr, "[ptrace-inject] detached, target resumed\n");
+    return true;
+}

--- a/src/inject/ptrace_injector.cpp
+++ b/src/inject/ptrace_injector.cpp
@@ -24,14 +24,48 @@
 #include <cstdio>
 #include <cstring>
 #include <fcntl.h>
-#include <sys/ptrace.h>
 #include <sys/uio.h>
-#include <sys/user.h>
 #include <sys/wait.h>
 #include <thread>
 #include <unistd.h>
 #include <vector>
+
+#ifdef __linux__
 #include <linux/elf.h>
+#include <sys/ptrace.h>
+#include <sys/user.h>
+#else
+// macOS host build — provide Linux ptrace constants so the code compiles.
+// These match the values from <linux/ptrace.h> and <linux/elf.h>.
+#include <sys/ptrace.h>
+
+#ifndef NT_PRSTATUS
+#define NT_PRSTATUS 1
+#endif
+#ifndef PTRACE_ATTACH
+#define PTRACE_ATTACH 16
+#endif
+#ifndef PTRACE_DETACH
+#define PTRACE_DETACH 17
+#endif
+#ifndef PTRACE_CONT
+#define PTRACE_CONT 7
+#endif
+#ifndef PTRACE_GETREGSET
+#define PTRACE_GETREGSET 0x4204
+#endif
+#ifndef PTRACE_SETREGSET
+#define PTRACE_SETREGSET 0x4205
+#endif
+
+// macOS ptrace has signature: int ptrace(int, pid_t, caddr_t, int)
+// Linux ptrace has signature: long ptrace(enum, pid_t, void*, void*)
+// Wrap to match Linux calling convention used throughout this file.
+static inline long linux_ptrace(int request, pid_t pid, void *addr, void *data) {
+    return ptrace(request, pid, (caddr_t)addr, (int)(intptr_t)data);
+}
+#define ptrace(req, pid, addr, data) linux_ptrace(req, pid, (void*)(intptr_t)(addr), (void*)(intptr_t)(data))
+#endif // __linux__
 
 // user_regs_struct for ARM64
 struct arm64_regs {
@@ -178,10 +212,14 @@ bool ptrace_inject(int pid, const char *so_path) {
     }
     fprintf(stderr, "[ptrace-inject] libdl: %s @ 0x%lx\n", libdl_disk_path, libdl_base);
 
-    // Use __loader_dlopen from linker64 to bypass namespace check.
-    // Signature: void* __loader_dlopen(const char* filename, int flags, const void* caller_addr);
-    // Find linker64 base in target process
-    rewind(f);
+    // Find dlerror for diagnostics
+    uintptr_t dlerror_offset = find_symbol(libdl_disk_path, "dlerror");
+    uintptr_t dlerror_addr = dlerror_offset ? (libdl_base + dlerror_offset) : 0;
+
+    // Find __loader_dlopen from linker64.
+    // We use the 3-arg version so we can control caller_addr for namespace
+    // resolution. The 2-arg dlopen stub derives caller from LR, which is 0
+    // in our ptrace call setup — causing the linker to use the wrong namespace.
     f = fopen(maps_path, "r");
     uintptr_t linker_base = 0;
     char linker_disk_path[256] = "";
@@ -206,21 +244,18 @@ bool ptrace_inject(int pid, const char *so_path) {
     }
     if (f) fclose(f);
     if (!linker_base || !linker_disk_path[0]) {
-        fprintf(stderr, "[ptrace-inject] linker64 not found in target maps\n");
+        fprintf(stderr, "[ptrace-inject] linker64 not found\n");
         ptrace(PTRACE_DETACH, pid, 0, 0);
         return false;
     }
     uintptr_t loader_dlopen_offset = find_symbol(linker_disk_path, "__loader_dlopen");
     if (!loader_dlopen_offset) {
-        fprintf(stderr, "[ptrace-inject] __loader_dlopen not found in linker64\n");
+        fprintf(stderr, "[ptrace-inject] __loader_dlopen not found\n");
         ptrace(PTRACE_DETACH, pid, 0, 0);
         return false;
     }
     uintptr_t dlopen_addr = linker_base + loader_dlopen_offset;
-    fprintf(stderr, "[ptrace-inject] linker64: %s @ 0x%lx\n", linker_disk_path, linker_base);
     fprintf(stderr, "[ptrace-inject] __loader_dlopen @ 0x%lx\n", dlopen_addr);
-
-    uintptr_t caller_addr = linker_base + 0x1000;
 
     // Save original regs
     arm64_regs orig_regs;
@@ -229,21 +264,83 @@ bool ptrace_inject(int pid, const char *so_path) {
         return false;
     }
 
-    // Write path to target's stack (below current sp)
+    // Write path to a known RW page: libc's timezone variable.
+    // Writing below the stack (sp - 512) can land on unmapped/guard pages
+    // in freshly-forked zygote children. The signal-based injector uses
+    // timezone for the same reason — it's always mapped RW in .bss.
+    uintptr_t libc_base = find_library_base(pid, "libc.so");
+    if (!libc_base) {
+        fprintf(stderr, "[ptrace-inject] libc.so not found\n");
+        ptrace(PTRACE_DETACH, pid, 0, 0);
+        return false;
+    }
+
+    // Resolve libc disk path for symbol lookup
+    f = fopen(maps_path, "r");
+    char libc_disk_path[256] = "";
+    while (f && fgets(line, sizeof(line), f)) {
+        if (strstr(line, "libc.so") && strstr(line, "r--p")) {
+            const char* path_start = strchr(line, '/');
+            if (path_start) {
+                size_t len = strlen(path_start);
+                while (len > 0 && (path_start[len-1] == '\n' || path_start[len-1] == ' '))
+                    len--;
+                if (len < sizeof(libc_disk_path)) {
+                    memcpy(libc_disk_path, path_start, len);
+                    libc_disk_path[len] = 0;
+                }
+            }
+            break;
+        }
+    }
+    if (f) fclose(f);
+
+    // Use timezone (.bss, RW) as scratch space for the path string
+    uintptr_t timezone_offset = find_symbol(libc_disk_path, "timezone");
+    uintptr_t path_addr = 0;
+    std::vector<uint8_t> path_backup;
+
+    if (timezone_offset) {
+        path_addr = libc_base + timezone_offset;
+        // Back up original value so we can restore it
+        path_backup = read_memory(pid, path_addr, 64);
+        fprintf(stderr, "[ptrace-inject] using timezone @ 0x%lx for path scratch\n", path_addr);
+    } else {
+        // Fallback: use stack
+        path_addr = (orig_regs.sp - 512) & ~0xFULL;
+        fprintf(stderr, "[ptrace-inject] timezone not found, using stack @ 0x%lx\n", path_addr);
+    }
+
     size_t path_len = strlen(so_path) + 1;
-    uintptr_t path_addr = (orig_regs.sp - 512) & ~0xFULL;
     std::vector<uint8_t> path_bytes(so_path, so_path + path_len);
     if (!write_memory(pid, path_addr, path_bytes)) {
-        fprintf(stderr, "[ptrace-inject] failed to write path to target stack\n");
+        fprintf(stderr, "[ptrace-inject] failed to write path string\n");
         ptrace_set_regs(pid, &orig_regs);
         ptrace(PTRACE_DETACH, pid, 0, 0);
         return false;
     }
 
-    // Call __loader_dlopen(path, RTLD_NOW=2, caller_addr=libc)
+    // Verify the path was written correctly
+    auto verify = read_memory(pid, path_addr, path_len);
+    if (verify.empty() || memcmp(verify.data(), so_path, path_len) != 0) {
+        fprintf(stderr, "[ptrace-inject] path verify FAILED\n");
+        if (!path_backup.empty()) write_memory(pid, path_addr, path_backup);
+        ptrace(PTRACE_DETACH, pid, 0, 0);
+        return false;
+    }
+    fprintf(stderr, "[ptrace-inject] path verified @ 0x%lx: %s\n", path_addr, so_path);
+
+    // caller_addr for __loader_dlopen determines the namespace.
+    // On Android 11+, "classloader-namespace-shared" is the app namespace.
+    // Using libc_base puts us in the default/platform namespace, which CAN
+    // load from /data/local/tmp/. The app's classloader namespace cannot.
+    uintptr_t caller_addr = libc_base;
+
+    // Call __loader_dlopen(path, RTLD_NOW=2, caller_addr)
     arm64_regs saved_regs;
     if (!ptrace_call_function(pid, &saved_regs, dlopen_addr, path_addr, 2, caller_addr)) {
         fprintf(stderr, "[ptrace-inject] dlopen call failed\n");
+        if (!path_backup.empty()) write_memory(pid, path_addr, path_backup);
         ptrace_set_regs(pid, &orig_regs);
         ptrace(PTRACE_DETACH, pid, 0, 0);
         return false;
@@ -252,12 +349,31 @@ bool ptrace_inject(int pid, const char *so_path) {
     // Read return value (dlopen handle) from x0
     arm64_regs ret_regs;
     if (!ptrace_get_regs(pid, &ret_regs)) {
+        if (!path_backup.empty()) write_memory(pid, path_addr, path_backup);
         ptrace_set_regs(pid, &orig_regs);
         ptrace(PTRACE_DETACH, pid, 0, 0);
         return false;
     }
     uint64_t handle = ret_regs.x[0];
-    fprintf(stderr, "[ptrace-inject] dlopen returned 0x%lx\n", handle);
+    fprintf(stderr, "[ptrace-inject] dlopen returned 0x%llx\n", (unsigned long long)handle);
+
+    // If dlopen failed, call dlerror() for diagnostics
+    if (handle == 0 && dlerror_addr) {
+        arm64_regs dlerr_regs;
+        if (ptrace_call_function(pid, &dlerr_regs, dlerror_addr, 0, 0)) {
+            arm64_regs after_dlerr;
+            if (ptrace_get_regs(pid, &after_dlerr) && after_dlerr.x[0] != 0) {
+                auto err_bytes = read_memory(pid, after_dlerr.x[0], 256);
+                if (!err_bytes.empty()) {
+                    err_bytes.push_back(0);
+                    fprintf(stderr, "[ptrace-inject] dlerror: %s\n", (const char*)err_bytes.data());
+                }
+            }
+        }
+    }
+
+    // Restore timezone scratch space
+    if (!path_backup.empty()) write_memory(pid, path_addr, path_backup);
 
     // Restore original registers
     if (!ptrace_set_regs(pid, &orig_regs)) {

--- a/src/librenef/cmd/cmd.cpp
+++ b/src/librenef/cmd/cmd.cpp
@@ -113,7 +113,10 @@ CommandResult CommandRegistry::dispatch(int client_fd, const char* cmd_buffer, s
         return CommandResult(false, "Unknown command: " + cmd_name);
     }
 
-    if (sock.is_connected()) {
+    // Drain stale agent output before most commands. Skip for watch —
+    // the hook output we want to display may already be in the buffer
+    // (hook fired between exec return and watch start).
+    if (sock.is_connected() && cmd_name != "watch") {
         sock.drain_buffer();
     }
 

--- a/src/librenef/cmd/cmd_eval.cpp
+++ b/src/librenef/cmd/cmd_eval.cpp
@@ -10,6 +10,8 @@
 #include <cstring>
 #include <signal.h>
 
+extern bool ptrace_resume(int pid);
+
 class Eval : public CommandDispatcher {
 public:
     std::string get_name() const override {
@@ -51,14 +53,15 @@ public:
         ssize_t sent = socket_helper.send_data(command.c_str(), command.length());
         fprintf(stderr, "[DEBUG exec] Actually sent %zd bytes\n", sent);
 
-        // Spawn gate: if process was frozen by spawn, resume it now.
-        // The exec data is already buffered in the kernel socket buffer,
-        // so the agent will read and install hooks before the main thread
-        // reaches onCreate.
+        // Spawn gate: if process was frozen by spawn (ptrace-stopped), resume
+        // it now. The exec data has already been sent to the agent's command
+        // thread (which runs independently of the ptrace-stopped main thread).
+        // We detach ptrace so the main thread can continue to onCreate, which
+        // will now hit the hooks the script installed.
         int gated = CommandRegistry::instance().gated_pid;
         if (gated > 0 && gated == pid) {
             fprintf(stderr, "[spawn-gate] Resuming gated process (pid=%d)\n", gated);
-            kill(gated, SIGCONT);
+            ptrace_resume(gated);
             CommandRegistry::instance().gated_pid = -1;
         }
 
@@ -69,15 +72,20 @@ public:
         bool script_done = false;
         int timeout_count = 0;
         const int max_timeout = 50;
+        int iterations = 0;
+        int total_bytes = 0;
 
         while (!script_done && timeout_count < max_timeout) {
             struct pollfd pfd = {sock, POLLIN, 0};
             int ret = poll(&pfd, 1, 100);
+            iterations++;
 
             if (ret > 0 && (pfd.revents & POLLIN)) {
                 ssize_t n = recv(sock, buffer, sizeof(buffer) - 1, 0);
                 if (n > 0) {
                     buffer[n] = '\0';
+                    total_bytes += n;
+                    fprintf(stderr, "[eval-debug] recv %zd bytes (total %d)\n", n, total_bytes);
                     write(client_fd, buffer, n);
 
                     if (strstr(buffer, "\342\234\223 Lua executed") || strstr(buffer, "\342\234\227 Lua")) {
@@ -85,14 +93,19 @@ public:
                     }
                     timeout_count = 0;
                 } else if (n == 0) {
+                    fprintf(stderr, "[eval-debug] recv returned 0 (connection closed)\n");
                     break;
                 }
             } else if (ret == 0) {
                 timeout_count++;
             } else {
+                fprintf(stderr, "[eval-debug] poll error: %s\n", strerror(errno));
                 break;
             }
         }
+
+        fprintf(stderr, "[eval-debug] loop done: iterations=%d, total_bytes=%d, script_done=%d, timeout_count=%d\n",
+                iterations, total_bytes, script_done, timeout_count);
 
         fcntl(sock, F_SETFL, flags);
 

--- a/src/librenef/cmd/cmd_eval.cpp
+++ b/src/librenef/cmd/cmd_eval.cpp
@@ -53,17 +53,8 @@ public:
         ssize_t sent = socket_helper.send_data(command.c_str(), command.length());
         fprintf(stderr, "[DEBUG exec] Actually sent %zd bytes\n", sent);
 
-        // Spawn gate: if process was frozen by spawn (ptrace-stopped), resume
-        // it now. The exec data has already been sent to the agent's command
-        // thread (which runs independently of the ptrace-stopped main thread).
-        // We detach ptrace so the main thread can continue to onCreate, which
-        // will now hit the hooks the script installed.
         int gated = CommandRegistry::instance().gated_pid;
-        if (gated > 0 && gated == pid) {
-            fprintf(stderr, "[spawn-gate] Resuming gated process (pid=%d)\n", gated);
-            ptrace_resume(gated);
-            CommandRegistry::instance().gated_pid = -1;
-        }
+        bool need_resume = (gated > 0 && gated == pid);
 
         int flags = fcntl(sock, F_GETFL, 0);
         fcntl(sock, F_SETFL, flags | O_NONBLOCK);
@@ -71,7 +62,7 @@ public:
         char buffer[4096];
         bool script_done = false;
         int timeout_count = 0;
-        const int max_timeout = 50;
+        const int max_timeout = need_resume ? 5 : 50;
         int iterations = 0;
         int total_bytes = 0;
 
@@ -106,6 +97,13 @@ public:
 
         fprintf(stderr, "[eval-debug] loop done: iterations=%d, total_bytes=%d, script_done=%d, timeout_count=%d\n",
                 iterations, total_bytes, script_done, timeout_count);
+
+        if (need_resume) {
+            fprintf(stderr, "[spawn-gate] Script delivered (%d bytes), resuming (pid=%d)\n",
+                    total_bytes, gated);
+            ptrace_resume(gated);
+            CommandRegistry::instance().gated_pid = -1;
+        }
 
         fcntl(sock, F_SETFL, flags);
 

--- a/src/librenef/cmd/cmd_load.cpp
+++ b/src/librenef/cmd/cmd_load.cpp
@@ -73,13 +73,8 @@ public:
         std::string command = "hexexec " + hex + "\n";
         socket_helper.send_data(command.c_str(), command.length());
 
-        // Spawn gate: resume ptrace-stopped process after script is delivered
         int gated = CommandRegistry::instance().gated_pid;
-        if (gated > 0 && gated == pid) {
-            fprintf(stderr, "[spawn-gate] Resuming gated process (pid=%d)\n", gated);
-            ptrace_resume(gated);
-            CommandRegistry::instance().gated_pid = -1;
-        }
+        bool need_resume = (gated > 0 && gated == pid);
 
         int flags = fcntl(sock, F_GETFL, 0);
         fcntl(sock, F_SETFL, flags | O_NONBLOCK);
@@ -110,6 +105,12 @@ public:
             } else {
                 break;
             }
+        }
+
+        if (need_resume) {
+            fprintf(stderr, "[spawn-gate] Script delivered, resuming (pid=%d)\n", gated);
+            ptrace_resume(gated);
+            CommandRegistry::instance().gated_pid = -1;
         }
 
         fcntl(sock, F_SETFL, flags);

--- a/src/librenef/cmd/cmd_load.cpp
+++ b/src/librenef/cmd/cmd_load.cpp
@@ -12,6 +12,8 @@
 #include <sys/socket.h>
 #include <signal.h>
 
+extern bool ptrace_resume(int pid);
+
 static std::string read_file(const char* path) {
     FILE* f = fopen(path, "rb");
     if (!f) return "";
@@ -71,11 +73,11 @@ public:
         std::string command = "hexexec " + hex + "\n";
         socket_helper.send_data(command.c_str(), command.length());
 
-        // Spawn gate: resume frozen process after script data is buffered
+        // Spawn gate: resume ptrace-stopped process after script is delivered
         int gated = CommandRegistry::instance().gated_pid;
         if (gated > 0 && gated == pid) {
             fprintf(stderr, "[spawn-gate] Resuming gated process (pid=%d)\n", gated);
-            kill(gated, SIGCONT);
+            ptrace_resume(gated);
             CommandRegistry::instance().gated_pid = -1;
         }
 

--- a/src/librenef/cmd/cmd_resume.cpp
+++ b/src/librenef/cmd/cmd_resume.cpp
@@ -4,6 +4,8 @@
 #include <unistd.h>
 #include <signal.h>
 
+extern bool ptrace_resume(int pid);
+
 class ResumeCommand : public CommandDispatcher {
 public:
   std::string get_name() const override { return "resume"; }
@@ -22,7 +24,7 @@ public:
       return CommandResult(true, "No gated process");
     }
 
-    kill(gated, SIGCONT);
+    ptrace_resume(gated);
     CommandRegistry::instance().gated_pid = -1;
 
     char msg[128];

--- a/src/librenef/cmd/cmd_spawn.cpp
+++ b/src/librenef/cmd/cmd_spawn.cpp
@@ -13,6 +13,12 @@
 #include <chrono>
 #include <signal.h>
 #include <sys/ioctl.h>
+#include <sys/ptrace.h>
+#include <sys/wait.h>
+
+#ifndef PTRACE_ATTACH
+#define PTRACE_ATTACH 16
+#endif
 
 #define RENEF_PAYLOAD_PATH "/data/local/tmp/libagent.so"
 
@@ -163,13 +169,11 @@ public:
 
     bool is_injected;
     if (params.pause) {
-      // Spawn gate: use ptrace-based injection. This STOPS the target
-      // main thread before any app code runs, injects the agent, and
-      // leaves the target stopped. Main thread won't reach onCreate until
-      // we resume via ptrace_resume() later.
+      // ptrace_inject: stops main thread before app code, loads agent.
+      // Combined with deferred hooks, this catches the first call to any
+      // function — even in not-yet-loaded libraries.
       is_injected = ptrace_inject(pid, RENEF_PAYLOAD_PATH);
     } else {
-      // Normal injection path: signal-based, no ptrace.
       is_injected = inject(pid, RENEF_PAYLOAD_PATH);
     }
 
@@ -187,12 +191,13 @@ public:
       sock.set_session_key(session_key);
 
       if (params.pause) {
-        // Target is still stopped via ptrace. Mark it gated so the next
-        // exec/load command will call ptrace_resume() after the script
-        // is delivered.
+        // Main thread is ptrace-stopped. Script will be sent next.
+        // If target lib isn't loaded yet, agent defers the hook and polls
+        // for it. On ptrace_resume, main thread runs, lib loads, poll
+        // catches it, hook installed before first call.
         CommandRegistry::instance().gated_pid = pid;
-        std::cerr << "  [spawn-gate] target ptrace-stopped (pid=" << pid
-                  << "), will resume on first exec" << std::endl;
+        std::cerr << "  [spawn-gate] main thread frozen (pid=" << pid
+                  << "), will resume on first exec/load" << std::endl;
       }
 
       snprintf(response, sizeof(response), "OK %d\n", pid);

--- a/src/librenef/cmd/cmd_spawn.cpp
+++ b/src/librenef/cmd/cmd_spawn.cpp
@@ -13,7 +13,6 @@
 #include <chrono>
 #include <signal.h>
 #include <sys/ioctl.h>
-#include <linux/sockios.h>
 
 #define RENEF_PAYLOAD_PATH "/data/local/tmp/libagent.so"
 

--- a/src/librenef/cmd/cmd_spawn.cpp
+++ b/src/librenef/cmd/cmd_spawn.cpp
@@ -12,6 +12,8 @@
 #include <vector>
 #include <chrono>
 #include <signal.h>
+#include <sys/ioctl.h>
+#include <linux/sockios.h>
 
 #define RENEF_PAYLOAD_PATH "/data/local/tmp/libagent.so"
 
@@ -79,6 +81,8 @@ static SpawnParams parse_spawn_params(const char *cmd_buffer, size_t cmd_size) {
 }
 
 extern bool inject(int pid, const char *so_path);
+extern bool ptrace_inject(int pid, const char *so_path);
+extern bool ptrace_resume(int pid);
 
 class SpawnCommand : public CommandDispatcher {
 public:
@@ -158,13 +162,22 @@ public:
               << std::chrono::duration_cast<std::chrono::milliseconds>(after_pid - spawn_start).count()
               << "ms (pid=" << pid << ")" << std::endl;
 
-    bool is_injected = inject(pid, RENEF_PAYLOAD_PATH);
+    bool is_injected;
+    if (params.pause) {
+      // Spawn gate: use ptrace-based injection. This STOPS the target
+      // main thread before any app code runs, injects the agent, and
+      // leaves the target stopped. Main thread won't reach onCreate until
+      // we resume via ptrace_resume() later.
+      is_injected = ptrace_inject(pid, RENEF_PAYLOAD_PATH);
+    } else {
+      // Normal injection path: signal-based, no ptrace.
+      is_injected = inject(pid, RENEF_PAYLOAD_PATH);
+    }
 
     char response[64];
     if (is_injected) {
 
       // Close old agent connection BEFORE establishing new one
-      // (set_current_pid closes SocketHelper if PID changed)
       CommandRegistry::instance().set_current_pid(pid);
 
       int con_pid = sock.ensure_connection(pid);
@@ -175,14 +188,11 @@ public:
       sock.set_session_key(session_key);
 
       if (params.pause) {
-        // Spawn gate: freeze process AFTER agent is connected.
-        // The agent socket is open and buffered by kernel.
-        // Next exec command will SIGCONT before polling for response,
-        // so the agent reads buffered script data and installs hooks
-        // before the main thread reaches onCreate.
-        kill(pid, SIGSTOP);
+        // Target is still stopped via ptrace. Mark it gated so the next
+        // exec/load command will call ptrace_resume() after the script
+        // is delivered.
         CommandRegistry::instance().gated_pid = pid;
-        std::cerr << "  [spawn-gate] process frozen (pid=" << pid
+        std::cerr << "  [spawn-gate] target ptrace-stopped (pid=" << pid
                   << "), will resume on first exec" << std::endl;
       }
 

--- a/src/librenef/cmd/cmd_watch.cpp
+++ b/src/librenef/cmd/cmd_watch.cpp
@@ -39,7 +39,29 @@ public:
             return CommandResult(false, "Socket connection failed");
         }
 
-        std::cout << "[WATCH] Starting watch on agent socket fd=" << sock << ", client_fd=" << client_fd << "\n";
+        fprintf(stderr, "[WATCH] Starting watch on agent socket fd=%d, client_fd=%d\n", sock, client_fd);
+
+        // Drain any data already in socket buffer (e.g. hook output that
+        // fired between script execution and watch startup) and forward to client
+        {
+            int old_flags = fcntl(sock, F_GETFL, 0);
+            fcntl(sock, F_SETFL, old_flags | O_NONBLOCK);
+            char buf[4096];
+            ssize_t drained_total = 0;
+            while (true) {
+                ssize_t n = recv(sock, buf, sizeof(buf), 0);
+                if (n > 0) {
+                    write(client_fd, buf, n);
+                    drained_total += n;
+                } else {
+                    break;
+                }
+            }
+            fcntl(sock, F_SETFL, old_flags);
+            if (drained_total > 0) {
+                fprintf(stderr, "[WATCH] forwarded %zd bytes of buffered hook output\n", drained_total);
+            }
+        }
 
         const char* start_msg = "Watching hook output... (waiting for hooks to trigger)\n";
         write(client_fd, start_msg, strlen(start_msg));
@@ -53,20 +75,32 @@ public:
         char buffer[4096];
         bool running = true;
 
+        int poll_count = 0;
         while (running) {
             struct pollfd pfds[2];
             pfds[0] = {sock, POLLIN, 0};
             pfds[1] = {client_fd, POLLIN, 0};
 
             int ret = poll(pfds, 2, 1000);
+            poll_count++;
+            if (poll_count % 5 == 0) {
+                // Also try a non-blocking recv to see if there's data poll missed
+                char peek_buf[64];
+                ssize_t peek = recv(sock, peek_buf, sizeof(peek_buf), MSG_PEEK | MSG_DONTWAIT);
+                fprintf(stderr, "[WATCH] poll iter=%d, ret=%d, sock_rev=0x%x, client_rev=0x%x, peek=%zd\n",
+                        poll_count, ret, pfds[0].revents, pfds[1].revents, peek);
+                if (peek > 0) {
+                    fprintf(stderr, "[WATCH] peek data: %.*s\n", (int)peek, peek_buf);
+                }
+            }
 
             if (ret > 0) {
                 if (pfds[0].revents & POLLIN) {
                     ssize_t n = recv(sock, buffer, sizeof(buffer) - 1, 0);
-                    std::cout << "[WATCH] recv from agent: n=" << n << "\n";
+                    fprintf(stderr, "[WATCH] recv from agent: n=%zd\n", n);
                     if (n > 0) {
                         buffer[n] = '\0';
-                        std::cout << "[WATCH] Got data: " << buffer << "\n";
+                        fprintf(stderr, "[WATCH] Forwarding to client: %.*s\n", (int)n, buffer);
                         write(client_fd, buffer, n);
                     } else if (n == 0) {
                         const char* msg = "Agent disconnected\n";


### PR DESCRIPTION
# Spawn Gate (--pause) — Technical Background

## The Problem

When instrumenting Android apps, hooks need to be installed **before** the application's `onCreate` runs. This is critical for bypassing root detection, SSL pinning checks, and integrity verifications that execute during startup.

The challenge: injection takes time, and the app doesn't wait.

## Why the Previous Approach Failed

### Attempt 1: SIGSTOP/SIGCONT

The initial idea was simple: freeze the target process with `SIGSTOP` after injection, load the script, then `SIGCONT` to resume.

**Result:** The agent's command handler thread — which needs to receive and execute the script — was also frozen by SIGSTOP. SIGSTOP is process-wide; it stops every thread, not just the main thread. After SIGCONT, the ART runtime's internal state became inconsistent, and the agent never processed the buffered commands. The target appeared alive but was effectively unresponsive.

### Attempt 2: Agent-Side Java Hook

The next idea was to have the agent install a blocking Java hook on `ActivityThread.handleBindApplication` during its constructor. The hook would spin-wait until released, holding the main thread before `onCreate`.

**Result:** This approach had a fundamental timing problem. The existing signal-based injection mechanism (overwrite `malloc` with shellcode, send `SIGUSR1` to trigger) takes approximately 600ms from launch to completion. However, a typical Android app reaches `onCreate` within 200-300ms. By the time the agent loads and could install the hook, `onCreate` has already fired. The hook catches nothing.

### Attempt 3: Zygote Pre-Injection

The idea was to inject into the Zygote process itself, hook its `fork()` function, and intercept child processes at birth — before any application code runs.

**Result:** Zygote is a minimal single-threaded process sitting in `ppoll()` waiting for fork requests. It has no GC thread, no JIT thread, no background threads. The signal-based injection (which relies on a thread calling `malloc` after receiving `SIGUSR1`) never triggers because Zygote's sole thread doesn't call `malloc` in response to signals. The shellcode sits in memory indefinitely, never executed.

## The Solution: Ptrace-Based Injection for --pause

The working approach uses `ptrace` exclusively for the `--pause` flag. Normal injection (without `--pause`) remains completely ptrace-free.

### How It Works

1. **Launch the app** via `monkey` — Zygote forks a new process
2. **Find the PID** via rapid polling (~25ms)
3. **`PTRACE_ATTACH`** — the kernel immediately stops the main thread. No application code can execute past this point, regardless of timing
4. **Inject the agent via ptrace-controlled execution:**
   - Write the library path (`/data/local/tmp/libagent.so`) to the target's stack using `process_vm_writev`
   - Save the current register state via `PTRACE_GETREGSET`
   - Set up a function call: `x0 = path`, `x1 = RTLD_NOW`, `x2 = libc_address` (fake caller for namespace bypass), `PC = __loader_dlopen`, `LR = 0`
   - `PTRACE_CONT` — the thread executes `__loader_dlopen`, which loads `libagent.so` and runs its constructor
   - The constructor spawns the agent's command handler thread (which is **not** ptrace-attached and runs freely)
   - When `dlopen` returns and jumps to `LR=0`, a SIGSEGV occurs. Ptrace catches this
   - Restore the original register state
5. **The main thread is still stopped**, but the agent's command handler thread is alive and accepting commands
6. **Client sends the script** — the command handler thread receives it, executes it, installs all hooks
7. **`PTRACE_DETACH`** — the main thread resumes from where it was frozen, continues to `onCreate`. All hooks are already in place

### Why __loader_dlopen

Android 10+ enforces linker namespaces. A regular `dlopen()` call checks the caller's return address to determine which namespace it belongs to. Since our ptrace-injected call doesn't originate from any library, the namespace check fails and `dlopen` returns NULL.

`__loader_dlopen` is the linker's internal function that accepts the caller address as an explicit parameter:

```c
void* __loader_dlopen(const char* filename, int flags, const void* caller_addr);
```

By passing a `libc.so` address as `caller_addr`, the linker believes the call originates from libc's namespace, which has permission to load libraries from `/data/local/tmp/`. This bypasses the namespace restriction without modifying any system configuration.

### Why Ptrace Doesn't Affect Detection

Anti-debugging checks read `/proc/self/status` and look for `TracerPid != 0`. In our implementation:

- Ptrace is attached **before** any application code runs (main thread is frozen at kernel level)
- Ptrace is detached **after** hooks are installed but **before** `onCreate` executes
- When the app's root detection code reads `/proc/self/status`, `TracerPid` is already `0`

The application never observes ptrace in its own process. From the app's perspective, no tracing ever occurred.

### Timing Comparison

```
Without --pause:
  T=0      Launch
  T=200ms  onCreate (root check) — NO HOOKS
  T=600ms  Injection complete, hooks installed — TOO LATE

With --pause:
  T=0      Launch
  T=100ms  PID found, PTRACE_ATTACH — main thread FROZEN
  T=110ms  dlopen(libagent.so) via ptrace
  T=120ms  Agent loaded, command thread running
  T=130ms  Script received, hooks installed
  T=130ms  PTRACE_DETACH — main thread resumes
  T=330ms  onCreate (root check) — HOOKS ACTIVE ✓
```

### Architecture

```
                        --pause flag?
                            │
                     ┌──────┴──────┐
                     │ NO          │ YES
                     ▼             ▼
              inject()       ptrace_inject()
           (signal-based)    (ptrace-based)
           - No ptrace       - PTRACE_ATTACH
           - SIGUSR1         - __loader_dlopen
           - malloc hook     - PTRACE_DETACH
```

Two completely separate code paths. The `--pause` flag is the only thing that activates ptrace. Everything else in renef remains ptrace-free.
